### PR TITLE
chore: add eslint, prettier and husky

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,5 +13,9 @@
     "ignorePatterns": [
         "dist/",
         "*.js"
-    ]
+    ],
+    "rules": {
+        "@typescript-eslint/ban-ts-comment": "off",
+        "@typescript-eslint/no-explicit-any": "warn"
+    }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,17 @@
+{
+    "parser": "@typescript-eslint/parser",
+    "plugins": [
+        "@typescript-eslint"
+    ],
+    "extends": [
+        "eslint:recommended",
+        "plugin:@typescript-eslint/recommended"
+    ],
+    "env": {
+        "node": true
+    },
+    "ignorePatterns": [
+        "dist/",
+        "*.js"
+    ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 .env
 dist/
+.vscode/
+.turbo/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+pnpm lint-staged

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,0 +1,6 @@
+{
+    "*.ts": [
+        "eslint --fix",
+        "prettier --write"
+    ]
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+    "semi": true,
+    "singleQuote": false
+}

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -1,8 +1,14 @@
-import { createRecordTool as createRecordToolMastra, updateRecordTool as updateRecordToolMastra } from "@amp-labs/ai/mastra";
-import { createRecordTool as createRecordToolAISDK, updateRecordTool as updateRecordToolAISDK } from "@amp-labs/ai/aisdk";  
+import {
+  createRecordTool as createRecordToolMastra,
+  updateRecordTool as updateRecordToolMastra,
+} from "@amp-labs/ai/mastra";
+import {
+  createRecordTool as createRecordToolAISDK,
+  updateRecordTool as updateRecordToolAISDK,
+} from "@amp-labs/ai/aisdk";
 
 // Use in your AI agent configuration
-const toolsVercel = [createRecordToolAISDK, updateRecordToolAISDK];
+export const toolsVercel = [createRecordToolAISDK, updateRecordToolAISDK];
 
 // Use in your Mastra workflow
-const toolsMastra = [createRecordToolMastra, updateRecordToolMastra];
+export const toolsMastra = [createRecordToolMastra, updateRecordToolMastra];

--- a/examples/package.json
+++ b/examples/package.json
@@ -12,5 +12,9 @@
   },
   "devDependencies": {
     "typescript": "^5.7.3"
+  },
+  "scripts": {
+    "lint": "eslint . --ext .ts",
+    "format": "prettier --write \"**/*.ts\""
   }
 }

--- a/examples/vercel-agent.ts
+++ b/examples/vercel-agent.ts
@@ -1,20 +1,20 @@
-import { openai } from '@ai-sdk/openai';
-import { generateObject, generateText } from 'ai';
-import { z } from 'zod';
+import { openai } from "@ai-sdk/openai";
+import { generateObject, generateText } from "ai";
+import { z } from "zod";
 import { createRecordTool, updateRecordTool } from "@amp-labs/ai/aisdk";
 
 // Vercel Agent with AI SDK tools by Ampersand
 // This is a simple example of how to use the AI SDK tools by Ampersand in a Vercel AI agent.
-async function handleCustomerQuery(query: string) {
-  const model = openai('gpt-4o');
+export async function handleCustomerQuery(query: string) {
+  const model = openai("gpt-4o");
 
   // First step: Classify the query type
   const { object: classification } = await generateObject({
     model,
     schema: z.object({
       reasoning: z.string(),
-      type: z.enum(['general', 'refund', 'technical']),
-      complexity: z.enum(['simple', 'complex']),
+      type: z.enum(["general", "refund", "technical"]),
+      complexity: z.enum(["simple", "complex"]),
     }),
     prompt: `Classify this customer query:
     ${query}
@@ -29,16 +29,16 @@ async function handleCustomerQuery(query: string) {
   // Set model and system prompt based on query type and complexity
   const { text: response } = await generateText({
     model:
-      classification.complexity === 'simple'
-        ? openai('gpt-4o-mini')
-        : openai('o3-mini'),
+      classification.complexity === "simple"
+        ? openai("gpt-4o-mini")
+        : openai("o3-mini"),
     system: {
       general:
-        'You are an expert customer service agent handling general inquiries.',
+        "You are an expert customer service agent handling general inquiries.",
       refund:
-        'You are a customer service agent specializing in refund requests. Follow company policy and collect necessary information.',
+        "You are a customer service agent specializing in refund requests. Follow company policy and collect necessary information.",
       technical:
-        'You are a technical support specialist with deep product knowledge. Focus on clear step-by-step troubleshooting.',
+        "You are a technical support specialist with deep product knowledge. Focus on clear step-by-step troubleshooting.",
     }[classification.type],
     prompt: query,
     tools: {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -8,9 +8,11 @@
   },
   "scripts": {
     "build": "vite build",
-    "start": "node dist/index.js",
+    "start": "npm run build && node dist/index.js",
     "inspect": "npx @modelcontextprotocol/inspector node dist/index.js",
-    "publish": "npm publish --access public"
+    "publish": "npm publish --access public",
+    "lint": "eslint src --ext .ts",
+    "format": "prettier --write \"src/**/*.ts\""
   },
   "publishConfig": {
     "access": "public",
@@ -23,7 +25,7 @@
   "author": "Ampersand",
   "description": "MCP server for Ampersand docs",
   "dependencies": {
-    "@amp-labs/ai": "^0.0.1-alpha.10",
+    "@amp-labs/ai": "^0.1.0",
     "@amp-labs/sdk-node-platform": "^0.2.3",
     "@amp-labs/sdk-node-write": "^0.2.3",
     "@modelcontextprotocol/sdk": "^1.6.1",
@@ -53,11 +55,9 @@
     "process": "^0.11.10",
     "rollup": "^4.37.0",
     "rollup-plugin-node-polyfills": "^0.2.1",
-    "sdk-node-platform": "link:@types/@amp-labs/sdk-node-platform",
-    "sdk-node-write": "link:@types/@amp-labs/sdk-node-write",
     "stream-browserify": "^3.0.0",
     "typescript": "^5.7.3",
-    "vite": "^5.4.14",
+    "vite": "^6.2.2",
     "vite-plugin-node": "^5.0.0",
     "vite-plugin-node-polyfills": "^0.23.0"
   },

--- a/mcp-server/src/connection.ts
+++ b/mcp-server/src/connection.ts
@@ -2,14 +2,12 @@ import { SDKNodePlatform } from "@amp-labs/sdk-node-platform";
 import { z } from "zod";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { providerSchema } from "./schemas";
-import {
-  Installation,
-} from "@amp-labs/sdk-node-platform/models/operations/updateinstallation";
+import { Installation } from "@amp-labs/sdk-node-platform/models/operations/updateinstallation";
 import { ClientSettings } from ".";
 
 export async function createConnectionManagerTools(
   server: Server,
-  settings?: ClientSettings
+  settings?: ClientSettings,
 ): Promise<void> {
   // @ts-ignore
   server.tool(
@@ -28,7 +26,7 @@ export async function createConnectionManagerTools(
           projectIdOrName:
             settings?.project || process.env.AMPERSAND_PROJECT_ID || "",
           provider: provider,
-        }
+        };
         const data = await ampersandClient.connections.list(body);
         console.log("[CHECK-CONNECTION] API call to listConnections: ", body);
 
@@ -36,7 +34,10 @@ export async function createConnectionManagerTools(
         if (data.length > 0) {
           // @ts-ignore
           const connection = data[0];
-          console.log("[CHECK-CONNECTION] API response from listConnections:", connection);
+          console.log(
+            "[CHECK-CONNECTION] API response from listConnections:",
+            connection,
+          );
           return {
             content: [
               {
@@ -66,7 +67,7 @@ export async function createConnectionManagerTools(
           ],
         };
       }
-    }
+    },
   );
 
   // @ts-ignore
@@ -89,22 +90,25 @@ export async function createConnectionManagerTools(
             settings?.integrationName ||
             process.env.AMPERSAND_INTEGRATION_NAME ||
             "",
-        }
-        console.log("[CHECK-INSTALLATION] API call to listInstallations: ", body);
+        };
+        console.log(
+          "[CHECK-INSTALLATION] API call to listInstallations: ",
+          body,
+        );
         const data = await ampersandClient.installations.list(body);
 
         console.log(
           "[CHECK-INSTALLATION] API response from listInstallations: ",
-          data
+          data,
         );
         // @ts-ignore
         const relevantInstallations = data.filter(
           // @ts-ignore
-          (inst) => inst.connection?.provider === provider.toLowerCase()
+          (inst) => inst.connection?.provider === provider.toLowerCase(),
         );
         console.log(
           "[CHECK-INSTALLATION] filtered installations: ",
-          relevantInstallations
+          relevantInstallations,
         );
 
         if (relevantInstallations.length > 0) {
@@ -142,7 +146,7 @@ export async function createConnectionManagerTools(
           ],
         };
       }
-    }
+    },
   );
 
   // @ts-ignore
@@ -179,7 +183,10 @@ export async function createConnectionManagerTools(
             },
           },
         };
-        console.log("[CREATE-INSTALLATION] API call to createInstallation: ", requestBody);
+        console.log(
+          "[CREATE-INSTALLATION] API call to createInstallation: ",
+          requestBody,
+        );
 
         const data = await ampersandClient.installations.create({
           projectIdOrName:
@@ -191,7 +198,10 @@ export async function createConnectionManagerTools(
           requestBody,
         });
 
-        console.log("[CREATE-INSTALLATION] API response from createInstallation: ", data);
+        console.log(
+          "[CREATE-INSTALLATION] API response from createInstallation: ",
+          data,
+        );
 
         // @ts-ignore
         const created = data.id !== undefined;
@@ -223,7 +233,7 @@ export async function createConnectionManagerTools(
           ],
         };
       }
-    }
+    },
   );
 }
 
@@ -237,7 +247,7 @@ export async function createConnectionManagerTools(
  */
 export async function ensureInstallation(
   provider: string,
-  settings?: ClientSettings
+  settings?: ClientSettings,
 ): Promise<string> {
   // Instantiate the Ampersand Node Platform Client
   const ampersandClient = new SDKNodePlatform({
@@ -247,17 +257,20 @@ export async function ensureInstallation(
     projectIdOrName:
       settings?.project || process.env.AMPERSAND_PROJECT_ID || "",
     provider: provider,
-  }
+  };
   console.log("[ENSURE-INSTALLATION] API call to listConnections: ", body);
 
   const connectionData = await ampersandClient.connections.list(body);
 
-  console.log("[ENSURE-INSTALLATION] API response from listConnections: ", connectionData);
+  console.log(
+    "[ENSURE-INSTALLATION] API response from listConnections: ",
+    connectionData,
+  );
 
   // @ts-ignore
   if (connectionData.length === 0) {
     throw new Error(
-      `No existing connections found for ${provider}. Please connect using OAuth.`
+      `No existing connections found for ${provider}. Please connect using OAuth.`,
     );
   }
 
@@ -268,7 +281,7 @@ export async function ensureInstallation(
 
   if (!groupRef) {
     throw new Error(
-      `Connection ${connectionId} for provider ${provider} does not have a groupRef.`
+      `Connection ${connectionId} for provider ${provider} does not have a groupRef.`,
     );
   }
 
@@ -276,23 +289,30 @@ export async function ensureInstallation(
     projectIdOrName:
       settings?.project || process.env.AMPERSAND_PROJECT_ID || "",
     integrationId:
-      settings?.integrationName|| process.env.AMPERSAND_INTEGRATION_NAME || "",
+      settings?.integrationName || process.env.AMPERSAND_INTEGRATION_NAME || "",
   });
 
   // @ts-ignore
   const relevantInstallations = installationData.filter(
     // @ts-ignore
-    (inst: Installation) => inst.connection?.provider === provider && inst.group?.groupRef === groupRef && inst.connection?.id === connectionId
+    (inst: Installation) =>
+      inst.connection?.provider === provider &&
+      inst.group?.groupRef === groupRef &&
+      inst.connection?.id === connectionId,
   );
 
-  console.log("[ENSURE-INSTALLATION] existing installation check", relevantInstallations, installationData);
+  console.log(
+    "[ENSURE-INSTALLATION] existing installation check",
+    relevantInstallations,
+    installationData,
+  );
 
   if (relevantInstallations.length === 0) {
     console.log(
       "[ENSURE-INSTALLATION] No existing installation found, creating one for connection:",
       connectionId,
       "group:",
-      groupRef
+      groupRef,
     );
 
     const requestBody = {
@@ -305,32 +325,43 @@ export async function ensureInstallation(
           proxy: { enabled: true },
         },
       },
-    }
+    };
 
     console.log(
-      "[ENSURE-INSTALLATION] API request to createInstallation", requestBody);
+      "[ENSURE-INSTALLATION] API request to createInstallation",
+      requestBody,
+    );
     const createData = await ampersandClient.installations.create({
-      projectIdOrName: settings?.project || process.env.AMPERSAND_PROJECT_ID || "",
-      integrationId: settings?.integrationName || process.env.AMPERSAND_INTEGRATION_NAME || "",
+      projectIdOrName:
+        settings?.project || process.env.AMPERSAND_PROJECT_ID || "",
+      integrationId:
+        settings?.integrationName ||
+        process.env.AMPERSAND_INTEGRATION_NAME ||
+        "",
       requestBody,
     });
 
-    console.log("[ENSURE-INSTALLATION] API response from createInstallation", createData);
+    console.log(
+      "[ENSURE-INSTALLATION] API response from createInstallation",
+      createData,
+    );
 
     // @ts-ignore
     if (createData.installation?.id) {
       // @ts-ignore
-      console.log(`[ENSURE-INSTALLATION]Installation created for ${provider}, Installation ID: ${createData.installation.id}`);
+      console.log(
+        `[ENSURE-INSTALLATION]Installation created for ${provider}, Installation ID: ${createData.installation.id}`,
+      );
       // @ts-ignore
       return createData.installation.id;
     } else {
       throw new Error(
-        `Failed to create installation for ${provider}. API response: ${JSON.stringify(createData)}`
+        `Failed to create installation for ${provider}. API response: ${JSON.stringify(createData)}`,
       );
     }
   } else {
     console.log(
-      `[ENSURE-INSTALLATION]Installation already exists for ${provider} with ID: ${relevantInstallations[0].id}`
+      `[ENSURE-INSTALLATION]Installation already exists for ${provider} with ID: ${relevantInstallations[0].id}`,
     );
     return relevantInstallations[0].id;
   }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,53 +1,60 @@
 import "./instrument";
 import * as Sentry from "@sentry/node";
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { connectServer } from './session';
-import { initialize } from './initialize';
-import { createSendRequestTool, createSendReadRequestTool } from './request';
-import { createStartOAuthTool } from './oauth';
-import { createCreateTool, createUpdateTool } from './write';
-import express from 'express';
-import { createConnectionManagerTools } from './connection';
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { connectServer } from "./session";
+import { initialize } from "./initialize";
+import { createSendRequestTool, createSendReadRequestTool } from "./request";
+import { createStartOAuthTool } from "./oauth";
+import { createCreateTool, createUpdateTool } from "./write";
+import express from "express";
+import { createConnectionManagerTools } from "./connection";
 
 const args = process.argv.slice(2);
-const useStdioTransport = args.includes('--transport') && args[args.indexOf('--transport') + 1] === 'stdio';
-const project = args.includes('--project') ? args[args.indexOf('--project') + 1] : process.env.AMPERSAND_PROJECT_ID || "";
-const integrationName = args.includes('--integrationName') ? args[args.indexOf('--integrationName') + 1] : process.env.AMPERSAND_INTEGRATION_NAME || "";
-const groupRef = args.includes('--groupRef') ? args[args.indexOf('--groupRef') + 1] : process.env.AMPERSAND_GROUP_REF || "";
+const useStdioTransport =
+  args.includes("--transport") &&
+  args[args.indexOf("--transport") + 1] === "stdio";
+const project = args.includes("--project")
+  ? args[args.indexOf("--project") + 1]
+  : process.env.AMPERSAND_PROJECT_ID || "";
+const integrationName = args.includes("--integrationName")
+  ? args[args.indexOf("--integrationName") + 1]
+  : process.env.AMPERSAND_INTEGRATION_NAME || "";
+const groupRef = args.includes("--groupRef")
+  ? args[args.indexOf("--groupRef") + 1]
+  : process.env.AMPERSAND_GROUP_REF || "";
 
 export const clientSettings = {
-    project: project,
-    integrationName: integrationName,
-    apiKey: process.env.AMPERSAND_API_KEY || "",
-    groupRef: groupRef
-}
-
+  project: project,
+  integrationName: integrationName,
+  apiKey: process.env.AMPERSAND_API_KEY || "",
+  groupRef: groupRef,
+};
 
 export type ClientSettings = typeof clientSettings;
 
 async function main(): Promise<express.Application | undefined> {
-    // @ts-ignore
-    const server = initialize() as Server;
-    // Hide search tool for now, since we will introduce a searchRecordsTool later
-    // await createSearchTool(server);
-    await createStartOAuthTool(server, clientSettings);
-    await createSendRequestTool(server, clientSettings);
-    await createSendReadRequestTool(server, clientSettings);
-    await createConnectionManagerTools(server, clientSettings);
-    await createCreateTool(server, clientSettings);
-    await createUpdateTool(server, clientSettings);
-    const app = await connectServer(server, useStdioTransport, clientSettings);
-    return app;
+  // @ts-ignore
+  const server = initialize() as Server;
+  // Hide search tool for now, since we will introduce a searchRecordsTool later
+  // await createSearchTool(server);
+  await createStartOAuthTool(server, clientSettings);
+  await createSendRequestTool(server, clientSettings);
+  await createSendReadRequestTool(server, clientSettings);
+  await createConnectionManagerTools(server, clientSettings);
+  await createCreateTool(server, clientSettings);
+  await createUpdateTool(server, clientSettings);
+  const app = await connectServer(server, useStdioTransport, clientSettings);
+  return app;
 }
 
 let mcpApp: Promise<express.Application | undefined> | null = null;
 
 try {
-    mcpApp = main();
+  mcpApp = main();
 } catch (error: any) {
-    console.error('Fatal error in trying to initialize MCP server: ', error);
-    Sentry.captureException(error);
-    process.exit(1);
+  console.error("Fatal error in trying to initialize MCP server: ", error);
+  Sentry.captureException(error);
+  process.exit(1);
 }
 
 export { mcpApp };

--- a/mcp-server/src/initialize.ts
+++ b/mcp-server/src/initialize.ts
@@ -1,11 +1,11 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { SERVER_NAME, SERVER_VERSION } from './settings.js';
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { SERVER_NAME, SERVER_VERSION } from "./settings.js";
 
 export function initialize(): McpServer {
-    console.error('Initializing MCP Server...');
-    const server = new McpServer({
-        name: SERVER_NAME,
-        version: SERVER_VERSION,
-    });
-    return server;
-} 
+  console.error("Initializing MCP Server...");
+  const server = new McpServer({
+    name: SERVER_NAME,
+    version: SERVER_VERSION,
+  });
+  return server;
+}

--- a/mcp-server/src/oauth.ts
+++ b/mcp-server/src/oauth.ts
@@ -1,4 +1,3 @@
-import { z } from "zod";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { providerSchema } from "./schemas";
 import { ClientSettings } from ".";
@@ -6,7 +5,7 @@ import crypto from "crypto";
 
 export async function createStartOAuthTool(
   server: Server,
-  settings?: ClientSettings
+  settings?: ClientSettings,
 ): Promise<void> {
   // @ts-ignore
   server.tool(
@@ -30,11 +29,14 @@ export async function createStartOAuthTool(
           },
           body: JSON.stringify({ provider, consumerRef, groupRef, projectId }),
         };
-        console.log("[START-OAUTH] API request to oauthConnect: ", options.body);
+        console.log(
+          "[START-OAUTH] API request to oauthConnect: ",
+          options.body,
+        );
 
         const response = await fetch(
           "https://api.withampersand.com/v1/oauth-connect",
-          options
+          options,
         );
         const data = await response.text();
         console.log("[START-OAUTH] API response from oauthConnect: ", data);
@@ -48,9 +50,9 @@ export async function createStartOAuthTool(
           {
             type: "text",
             text: oAuthUrl,
-          }
+          },
         ],
       };
-    }
+    },
   );
 }

--- a/mcp-server/src/request.ts
+++ b/mcp-server/src/request.ts
@@ -1,12 +1,16 @@
 import { z } from "zod";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { ensureInstallation } from "./connection";
-import { endpointSchema, installationIdSchema, providerSchema } from "./schemas";
+import {
+  endpointSchema,
+  installationIdSchema,
+  providerSchema,
+} from "./schemas";
 import { ClientSettings } from ".";
 
 export async function createSendRequestTool(
   server: Server,
-  settings?: ClientSettings
+  settings?: ClientSettings,
 ): Promise<void> {
   // @ts-ignore
   server.tool(
@@ -49,13 +53,13 @@ export async function createSendRequestTool(
         settings,
         body,
       });
-    }
+    },
   );
 }
 
 export async function createSendReadRequestTool(
   server: Server,
-  settings?: ClientSettings
+  settings?: ClientSettings,
 ): Promise<void> {
   // @ts-ignore
   server.tool(
@@ -88,7 +92,7 @@ export async function createSendReadRequestTool(
         installationId,
         settings,
       });
-    }
+    },
   );
 }
 
@@ -110,7 +114,8 @@ async function callAmpersandProxy({
   body?: Record<string, any>;
 }) {
   try {
-    installationId = installationId || (await ensureInstallation(provider, settings));
+    installationId =
+      installationId || (await ensureInstallation(provider, settings));
     const fetchOptions: any = {
       method,
       headers: {
@@ -126,14 +131,22 @@ async function callAmpersandProxy({
       fetchOptions.body = JSON.stringify(body);
     }
 
-    console.log("[SEND-REQUEST] API request to proxy: ", endpoint, fetchOptions.body);
+    console.log(
+      "[SEND-REQUEST] API request to proxy: ",
+      endpoint,
+      fetchOptions.body,
+    );
 
     const response = await fetch(
       `https://proxy.withampersand.com/${endpoint}`,
-      fetchOptions
+      fetchOptions,
     );
 
-    console.log("[SEND-REQUEST] API response status from proxy: ", endpoint, response.status);
+    console.log(
+      "[SEND-REQUEST] API response status from proxy: ",
+      endpoint,
+      response.status,
+    );
 
     const data = await response.text();
     return {
@@ -153,7 +166,10 @@ async function callAmpersandProxy({
       ],
     };
   } catch (error) {
-    console.error(`Error in ${method === "GET" ? "sendReadRequest" : "sendRequest"} tool`, error);
+    console.error(
+      `Error in ${method === "GET" ? "sendReadRequest" : "sendRequest"} tool`,
+      error,
+    );
     return {
       isError: true,
       content: [

--- a/mcp-server/src/schemas.ts
+++ b/mcp-server/src/schemas.ts
@@ -2,13 +2,19 @@ import { z } from "zod";
 
 export const providerSchema = z
   .string()
-  .describe(`The SaaS API provider to connect to. Always use camelCase (e.g. "monday", "hubspot", "salesforce").`);
+  .describe(
+    `The SaaS API provider to connect to. Always use camelCase (e.g. "monday", "hubspot", "salesforce").`,
+  );
 
 export const endpointSchema = z
   .string()
-  .describe(`The endpoint to call on the provider, without the base URL, and including the version. (e.g. If the full URL is "my-workspace.my.salesforce.com/services/data/v60.0/sobjects/Account", the endpoint is "v60.0/sobjects/Account")`);
+  .describe(
+    `The endpoint to call on the provider, without the base URL, and including the version. (e.g. If the full URL is "my-workspace.my.salesforce.com/services/data/v60.0/sobjects/Account", the endpoint is "v60.0/sobjects/Account")`,
+  );
 
 export const installationIdSchema = z
   .string()
   .optional()
-  .describe(`The ID of the installation. If you don't know it, use the check-installation tool.`);
+  .describe(
+    `The ID of the installation. If you don't know it, use the check-installation tool.`,
+  );

--- a/mcp-server/src/search.ts
+++ b/mcp-server/src/search.ts
@@ -1,108 +1,118 @@
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { TrieveSDK, ChunkMetadata } from 'trieve-ts-sdk';
-import { z } from 'zod';
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { TrieveSDK, ChunkMetadata } from "trieve-ts-sdk";
+import { z } from "zod";
 
-export const SUBDOMAIN: string = 'ampersand-24eb5c1a';
-export const SERVER_URL: string = 'https://leaves.mintlify.com'; 
+export const SUBDOMAIN: string = "ampersand-24eb5c1a";
+export const SERVER_URL: string = "https://leaves.mintlify.com";
 
 interface SearchConfig {
-    trieveApiKey: string;
-    trieveDatasetId: string;
-    name: string;
+  trieveApiKey: string;
+  trieveDatasetId: string;
+  name: string;
 }
 
 interface SearchResult {
-    title: string;
-    content: string;
-    link: string;
+  title: string;
+  content: string;
+  link: string;
 }
 
-const DEFAULT_BASE_URL = 'https://api.mintlifytrieve.com';
+const DEFAULT_BASE_URL = "https://api.mintlifytrieve.com";
 
-export async function fetchSearchConfigurationAndOpenApi(subdomain: string): Promise<SearchConfig> {
-    try {
-        const url = `${SERVER_URL}/api/mcp/config/${subdomain}`;
-        const response = await fetch(url, { method: 'GET' });
+export async function fetchSearchConfigurationAndOpenApi(
+  subdomain: string,
+): Promise<SearchConfig> {
+  try {
+    const url = `${SERVER_URL}/api/mcp/config/${subdomain}`;
+    const response = await fetch(url, { method: "GET" });
 
-        if (!response.ok) {
-            let msg = '';
-            try {
-                const json = await response.json();
-                msg = json.error ?? String(response.status) + ' ' + response.statusText;
-            } catch {
-                msg = String(response.status) + ' ' + response.statusText;
-            }
-            throw new Error(`HTTP Error: ${msg}`);
-        }
-
-        const contentType = response.headers.get('content-type');
-        if (!contentType || !contentType.includes('application/json')) {
-            throw new Error('Response is not JSON');
-        }
-
-        return await response.json();
-    } catch (error) {
-        throw new Error('Failed to initialize: ' + error);
+    if (!response.ok) {
+      let msg = "";
+      try {
+        const json = await response.json();
+        msg = json.error ?? String(response.status) + " " + response.statusText;
+      } catch {
+        msg = String(response.status) + " " + response.statusText;
+      }
+      throw new Error(`HTTP Error: ${msg}`);
     }
+
+    const contentType = response.headers.get("content-type");
+    if (!contentType || !contentType.includes("application/json")) {
+      throw new Error("Response is not JSON");
+    }
+
+    return await response.json();
+  } catch (error) {
+    throw new Error("Failed to initialize: " + error);
+  }
 }
 
-async function search(query: string, config: SearchConfig): Promise<SearchResult[]> {
-    const trieve = new TrieveSDK({
-        apiKey: config.trieveApiKey,
-        datasetId: config.trieveDatasetId,
-        baseUrl: DEFAULT_BASE_URL,
-    });
+async function search(
+  query: string,
+  config: SearchConfig,
+): Promise<SearchResult[]> {
+  const trieve = new TrieveSDK({
+    apiKey: config.trieveApiKey,
+    datasetId: config.trieveDatasetId,
+    baseUrl: DEFAULT_BASE_URL,
+  });
 
-    const data = await trieve.autocomplete({
-        page_size: 10,
-        query,
-        search_type: 'fulltext',
-        extend_results: true,
-        score_threshold: 1,
-    });
+  const data = await trieve.autocomplete({
+    page_size: 10,
+    query,
+    search_type: "fulltext",
+    extend_results: true,
+    score_threshold: 1,
+  });
 
-    if (data.chunks === undefined || data.chunks.length === 0) {
-        throw new Error('No results found');
-    }
+  if (data.chunks === undefined || data.chunks.length === 0) {
+    throw new Error("No results found");
+  }
 
-    return data.chunks.map((result) => {
-        const chunk = result.chunk as ChunkMetadata & {
-            metadata: { title: string };
-            chunk_html: string;
-            link: string;
-        };
-        
-        return {
-            title: chunk.metadata.title,
-            content: chunk.chunk_html,
-            link: chunk.link,
-        };
-    });
+  return data.chunks.map((result) => {
+    const chunk = result.chunk as ChunkMetadata & {
+      metadata: { title: string };
+      chunk_html: string;
+      link: string;
+    };
+
+    return {
+      title: chunk.metadata.title,
+      content: chunk.chunk_html,
+      link: chunk.link,
+    };
+  });
 }
 
 export async function createSearchTool(server: Server): Promise<void> {
-    try {
-        const config = await fetchSearchConfigurationAndOpenApi(SUBDOMAIN);
-        // @ts-ignore
-        server.tool('search', `Search across the ${config.name} documentation to fetch relevant context for a given query`, {
+  try {
+    const config = await fetchSearchConfigurationAndOpenApi(SUBDOMAIN);
+    // @ts-ignore
+    server.tool(
+      "search",
+      `Search across the ${config.name} documentation to fetch relevant context for a given query`,
+      {
         query: z.string(),
-    }, async ({ query }: { query: string }) => {
+      },
+      async ({ query }: { query: string }) => {
         console.log("[SEARCH] call: ", query);
         const results = await search(query, config);
         const content = results.map((result) => {
-            const { title, content, link } = result;
-            const text = `Title: ${title}\nContent: ${content}\nLink: ${link}`;
-            return {
-                type: 'text' as const,
-                text,
-            };
+          const { title, content, link } = result;
+          const text = `Title: ${title}\nContent: ${content}\nLink: ${link}`;
+          return {
+            type: "text" as const,
+            text,
+          };
         });
 
         return {
-            content,
+          content,
         };
-    }); 
-    } catch (error) {
-        console.warn('Error in registering search tool:', error);
-    }
-} 
+      },
+    );
+  } catch (error) {
+    console.warn("Error in registering search tool:", error);
+  }
+}

--- a/mcp-server/src/session.ts
+++ b/mcp-server/src/session.ts
@@ -47,7 +47,7 @@ class TransportManager {
 export async function connectServer(
   server: Server,
   useStdioTransport: boolean,
-  settings: any
+  settings: any,
 ): Promise<express.Application | undefined> {
   if (useStdioTransport) {
     console.log("Connecting to MCP server over stdio");
@@ -87,7 +87,7 @@ export async function connectServer(
     }
     console.log("[SESSION] Settings: ", settings);
     currentTransport = new SSEServerTransport("/messages", res);
-    const sessionId = transportManager.addTransport(currentTransport, res);
+    transportManager.addTransport(currentTransport, res);
     await server.connect(currentTransport);
   });
 
@@ -109,7 +109,7 @@ export async function connectServer(
         console.error(
           "Error handling POST message for sessionId:",
           sessionId,
-          error
+          error,
         );
 
         // If there's a critical error, clean up the transport
@@ -128,11 +128,11 @@ export async function connectServer(
   app.listen(port, () => {
     if (port !== DEFAULT_PORT) {
       console.error(
-        `Port ${DEFAULT_PORT} is already in use. Ampersand MCP Server running on SSE at http://localhost:${port}/${SSE_SERVER_VERSION}`
+        `Port ${DEFAULT_PORT} is already in use. Ampersand MCP Server running on SSE at http://localhost:${port}/${SSE_SERVER_VERSION}`,
       );
     } else {
       console.error(
-        `Ampersand MCP Server running on SSE at http://localhost:${port}/${SSE_SERVER_VERSION}`
+        `Ampersand MCP Server running on SSE at http://localhost:${port}/${SSE_SERVER_VERSION}`,
       );
     }
   });

--- a/mcp-server/src/settings.ts
+++ b/mcp-server/src/settings.ts
@@ -1,2 +1,2 @@
-export const SERVER_NAME: string = '@amp-labs/mcp-docs-server';
-export const SERVER_VERSION: string = '0.0.1'; 
+export const SERVER_NAME: string = "@amp-labs/mcp-docs-server";
+export const SERVER_VERSION: string = "0.0.1";

--- a/mcp-server/src/write.ts
+++ b/mcp-server/src/write.ts
@@ -2,10 +2,16 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { createWriteActionTool } from "@amp-labs/ai/mcp";
 import { ClientSettings } from ".";
 
-export async function createCreateTool(server: Server, settings: ClientSettings): Promise<void> {
+export async function createCreateTool(
+  server: Server,
+  settings: ClientSettings,
+): Promise<void> {
   createWriteActionTool(server, "create", "create-record", settings);
 }
 
-export async function createUpdateTool(server: Server, settings: ClientSettings): Promise<void> {
+export async function createUpdateTool(
+  server: Server,
+  settings: ClientSettings,
+): Promise<void> {
   createWriteActionTool(server, "update", "update-record", settings);
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,17 @@
 {
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "eslint": "^8.57.0",
     "husky": "^8.0.0",
-    "prettier": "^3.0.0",
+    "lint-staged": "^15.2.0",
+    "prettier": "^3.2.5",
     "turbo": "^1.10.0"
+  },
+  "scripts": {
+    "prepare": "husky install",
+    "lint": "turbo run lint",
+    "format": "turbo run format"
   },
   "packageManager": "pnpm@8.9.0",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,11 +8,23 @@ importers:
 
   .:
     devDependencies:
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^6.21.0
+        version: 6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/parser':
+        specifier: ^6.21.0
+        version: 6.21.0(eslint@8.57.1)(typescript@5.8.3)
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.1
       husky:
         specifier: ^8.0.0
         version: 8.0.3
+      lint-staged:
+        specifier: ^15.2.0
+        version: 15.5.2
       prettier:
-        specifier: ^3.0.0
+        specifier: ^3.2.5
         version: 3.5.3
       turbo:
         specifier: ^1.10.0
@@ -46,8 +58,8 @@ importers:
   mcp-server:
     dependencies:
       '@amp-labs/ai':
-        specifier: ^0.0.1-alpha.10
-        version: 0.0.1-alpha.11(@mastra/core@0.9.4)(ai@4.3.16)
+        specifier: ^0.1.0
+        version: link:../sdk
       '@amp-labs/sdk-node-platform':
         specifier: ^0.2.3
         version: 0.2.3(@modelcontextprotocol/sdk@1.12.0)(zod@3.25.22)
@@ -130,12 +142,6 @@ importers:
       rollup-plugin-node-polyfills:
         specifier: ^0.2.1
         version: 0.2.1
-      sdk-node-platform:
-        specifier: link:@types/@amp-labs/sdk-node-platform
-        version: link:@types/@amp-labs/sdk-node-platform
-      sdk-node-write:
-        specifier: link:@types/@amp-labs/sdk-node-write
-        version: link:@types/@amp-labs/sdk-node-write
       stream-browserify:
         specifier: ^3.0.0
         version: 3.0.0
@@ -143,14 +149,14 @@ importers:
         specifier: ^5.7.3
         version: 5.8.3
       vite:
-        specifier: ^5.4.14
-        version: 5.4.19(@types/node@22.15.21)
+        specifier: ^6.2.2
+        version: 6.3.5(@types/node@22.15.21)
       vite-plugin-node:
         specifier: ^5.0.0
-        version: 5.0.1(vite@5.4.19)
+        version: 5.0.1(vite@6.3.5)
       vite-plugin-node-polyfills:
         specifier: ^0.23.0
-        version: 0.23.0(rollup@4.41.0)(vite@5.4.19)
+        version: 0.23.0(rollup@4.41.0)(vite@6.3.5)
 
   sdk:
     dependencies:
@@ -1458,6 +1464,43 @@ packages:
     dev: true
     optional: true
 
+  /@eslint-community/eslint-utils@4.7.0(eslint@8.57.1):
+    resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+    dependencies:
+      eslint: 8.57.1
+      eslint-visitor-keys: 3.4.3
+    dev: true
+
+  /@eslint-community/regexpp@4.12.1:
+    resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+    dev: true
+
+  /@eslint/eslintrc@2.1.4:
+    resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.4.1
+      espree: 9.6.1
+      globals: 13.24.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@eslint/js@8.57.1:
+    resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
   /@grpc/grpc-js@1.13.4:
     resolution: {integrity: sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==}
     engines: {node: '>=12.10.0'}
@@ -1476,6 +1519,28 @@ packages:
       protobufjs: 7.4.0
       yargs: 17.7.2
     dev: false
+
+  /@humanwhocodes/config-array@0.13.0:
+    resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
+    engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
+    dependencies:
+      '@humanwhocodes/object-schema': 2.0.3
+      debug: 4.4.1
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@humanwhocodes/module-importer@1.0.1:
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+    dev: true
+
+  /@humanwhocodes/object-schema@2.0.3:
+    resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
+    deprecated: Use @eslint/object-schema instead
+    dev: true
 
   /@isaacs/fs-minipass@4.0.1:
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
@@ -1757,6 +1822,27 @@ packages:
   /@neon-rs/load@0.0.4:
     resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
     dev: false
+
+  /@nodelib/fs.scandir@2.1.5:
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+    dev: true
+
+  /@nodelib/fs.stat@2.0.5:
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+    dev: true
+
+  /@nodelib/fs.walk@1.2.8:
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.19.1
+    dev: true
 
   /@opentelemetry/api-logs@0.57.2:
     resolution: {integrity: sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==}
@@ -3727,7 +3813,6 @@ packages:
 
   /@types/json-schema@7.0.15:
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
-    dev: false
 
   /@types/memcached@2.2.10:
     resolution: {integrity: sha512-AM9smvZN55Gzs2wRrqeMHVP7KE8KWgCJO/XL5yCly2xF6EKa4YlbpK+cLSAH4NG/Ah64HrlegmGqW8kYws7Vxg==}
@@ -3802,6 +3887,10 @@ packages:
       rollup: 4.41.0
     dev: true
 
+  /@types/semver@7.7.0:
+    resolution: {integrity: sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==}
+    dev: true
+
   /@types/send@0.17.4:
     resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
     dependencies:
@@ -3840,6 +3929,142 @@ packages:
     dependencies:
       '@types/node': 22.15.21
     dev: false
+
+  /@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.57.1)(typescript@5.8.3):
+    resolution: {integrity: sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^6.0.0 || ^6.0.0-alpha
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/scope-manager': 6.21.0
+      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.4.1
+      eslint: 8.57.1
+      graphemer: 1.4.0
+      ignore: 5.3.2
+      natural-compare: 1.4.0
+      semver: 7.7.2
+      ts-api-utils: 1.4.3(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3):
+    resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 6.21.0
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.4.1
+      eslint: 8.57.1
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/scope-manager@6.21.0:
+    resolution: {integrity: sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/visitor-keys': 6.21.0
+    dev: true
+
+  /@typescript-eslint/type-utils@6.21.0(eslint@8.57.1)(typescript@5.8.3):
+    resolution: {integrity: sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.8.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.8.3)
+      debug: 4.4.1
+      eslint: 8.57.1
+      ts-api-utils: 1.4.3(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/types@6.21.0:
+    resolution: {integrity: sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dev: true
+
+  /@typescript-eslint/typescript-estree@6.21.0(typescript@5.8.3):
+    resolution: {integrity: sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.4.1
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.3
+      semver: 7.7.2
+      ts-api-utils: 1.4.3(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/utils@6.21.0(eslint@8.57.1)(typescript@5.8.3):
+    resolution: {integrity: sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.1)
+      '@types/json-schema': 7.0.15
+      '@types/semver': 7.7.0
+      '@typescript-eslint/scope-manager': 6.21.0
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.8.3)
+      eslint: 8.57.1
+      semver: 7.7.2
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@typescript-eslint/visitor-keys@6.21.0:
+    resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.21.0
+      eslint-visitor-keys: 3.4.3
+    dev: true
+
+  /@ungap/structured-clone@1.3.0:
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    dev: true
 
   /@volar/language-core@2.4.14:
     resolution: {integrity: sha512-X6beusV0DvuVseaOEy7GoagS4rYHgDHnTrdOj5jeUb49fW5ceQyP9Ej5rBhqgz2wJggl+2fDbbojq1XKaxDi6w==}
@@ -3937,6 +4162,14 @@ packages:
       acorn: 8.14.1
     dev: false
 
+  /acorn-jsx@5.3.2(acorn@8.14.1):
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      acorn: 8.14.1
+    dev: true
+
   /acorn@8.14.1:
     resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
     engines: {node: '>=0.4.0'}
@@ -4005,7 +4238,6 @@ packages:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
-    dev: false
 
   /ajv@8.12.0:
     resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
@@ -4029,16 +4261,32 @@ packages:
     resolution: {integrity: sha512-itUAVzhczTmP2U5yX67xVpsbbOiquusbWVyA9N+sy6+r6YVbFkahXvNCeEPWEOMhwDYwbVbGHFkVL03N9I5g+Q==}
     dev: true
 
+  /ansi-escapes@7.0.0:
+    resolution: {integrity: sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==}
+    engines: {node: '>=18'}
+    dependencies:
+      environment: 1.1.0
+    dev: true
+
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
-    dev: false
+
+  /ansi-regex@6.1.0:
+    resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
+    engines: {node: '>=12'}
+    dev: true
 
   /ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
+
+  /ansi-styles@6.2.1:
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
+    dev: true
 
   /argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -4048,11 +4296,15 @@ packages:
 
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
-    dev: false
 
   /array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
     dev: false
+
+  /array-union@2.1.0:
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
+    dev: true
 
   /asn1.js@4.10.1:
     resolution: {integrity: sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==}
@@ -4177,6 +4429,13 @@ packages:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
     dependencies:
       balanced-match: 1.0.2
+
+  /braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+    dependencies:
+      fill-range: 7.1.1
+    dev: true
 
   /brorand@1.1.0:
     resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
@@ -4314,6 +4573,11 @@ packages:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  /callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+    dev: true
+
   /chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -4325,7 +4589,6 @@ packages:
   /chalk@5.4.1:
     resolution: {integrity: sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-    dev: false
 
   /chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
@@ -4348,6 +4611,21 @@ packages:
   /cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
     dev: false
+
+  /cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+    dependencies:
+      restore-cursor: 5.1.0
+    dev: true
+
+  /cli-truncate@4.0.0:
+    resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
+    engines: {node: '>=18'}
+    dependencies:
+      slice-ansi: 5.0.0
+      string-width: 7.2.0
+    dev: true
 
   /cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -4419,7 +4697,6 @@ packages:
 
   /colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
-    dev: false
 
   /colorspace@1.1.4:
     resolution: {integrity: sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==}
@@ -4434,6 +4711,11 @@ packages:
     dependencies:
       delayed-stream: 1.0.0
     dev: false
+
+  /commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
+    dev: true
 
   /compare-versions@6.1.1:
     resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
@@ -4556,7 +4838,6 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-    dev: false
 
   /crypto-browserify@3.12.1:
     resolution: {integrity: sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==}
@@ -4633,6 +4914,10 @@ packages:
     dependencies:
       ms: 2.1.3
 
+  /deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+    dev: true
+
   /define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
@@ -4705,6 +4990,20 @@ packages:
       randombytes: 2.1.0
     dev: true
 
+  /dir-glob@3.0.1:
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    engines: {node: '>=8'}
+    dependencies:
+      path-type: 4.0.0
+    dev: true
+
+  /doctrine@3.0.0:
+    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      esutils: 2.0.3
+    dev: true
+
   /domain-browser@4.22.0:
     resolution: {integrity: sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==}
     engines: {node: '>=10'}
@@ -4738,6 +5037,10 @@ packages:
       minimalistic-crypto-utils: 1.0.1
     dev: true
 
+  /emoji-regex@10.4.0:
+    resolution: {integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==}
+    dev: true
+
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
     dev: false
@@ -4765,6 +5068,11 @@ packages:
   /entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
+    dev: true
+
+  /environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
     dev: true
 
   /es-define-property@1.0.1:
@@ -4872,12 +5180,106 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  /eslint-scope@7.2.2:
+    resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+    dev: true
+
+  /eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /eslint@8.57.1:
+    resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
+    hasBin: true
+    dependencies:
+      '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.1)
+      '@eslint-community/regexpp': 4.12.1
+      '@eslint/eslintrc': 2.1.4
+      '@eslint/js': 8.57.1
+      '@humanwhocodes/config-array': 0.13.0
+      '@humanwhocodes/module-importer': 1.0.1
+      '@nodelib/fs.walk': 1.2.8
+      '@ungap/structured-clone': 1.3.0
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.1
+      doctrine: 3.0.0
+      escape-string-regexp: 4.0.0
+      eslint-scope: 7.2.2
+      eslint-visitor-keys: 3.4.3
+      espree: 9.6.1
+      esquery: 1.6.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 6.0.1
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      globals: 13.24.0
+      graphemer: 1.4.0
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      is-path-inside: 3.0.3
+      js-yaml: 4.1.0
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+      strip-ansi: 6.0.1
+      text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /espree@9.6.1:
+    resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      acorn: 8.14.1
+      acorn-jsx: 5.3.2(acorn@8.14.1)
+      eslint-visitor-keys: 3.4.3
+    dev: true
+
+  /esquery@1.6.0:
+    resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
+    engines: {node: '>=0.10'}
+    dependencies:
+      estraverse: 5.3.0
+    dev: true
+
+  /esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+    dependencies:
+      estraverse: 5.3.0
+    dev: true
+
+  /estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+    dev: true
+
   /estree-walker@0.6.1:
     resolution: {integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==}
     dev: true
 
   /estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+    dev: true
+
+  /esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
   /etag@1.8.1:
@@ -4889,6 +5291,10 @@ packages:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
     dev: false
+
+  /eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+    dev: true
 
   /events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
@@ -4911,6 +5317,21 @@ packages:
     dependencies:
       md5.js: 1.3.5
       safe-buffer: 5.2.1
+    dev: true
+
+  /execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.3.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
     dev: true
 
   /exit-hook@4.0.0:
@@ -5016,9 +5437,23 @@ packages:
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  /fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+    dev: true
+
   /fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
-    dev: false
+
+  /fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+    dev: true
 
   /fast-redact@3.5.0:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
@@ -5045,6 +5480,23 @@ packages:
       tar: 6.2.1
     dev: false
 
+  /fastq@1.19.1:
+    resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+    dependencies:
+      reusify: 1.1.0
+    dev: true
+
+  /fdir@6.4.6(picomatch@4.0.2):
+    resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+    dependencies:
+      picomatch: 4.0.2
+    dev: true
+
   /fecha@4.2.3:
     resolution: {integrity: sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==}
     dev: false
@@ -5056,6 +5508,20 @@ packages:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
     dev: false
+
+  /file-entry-cache@6.0.1:
+    resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    dependencies:
+      flat-cache: 3.2.0
+    dev: true
+
+  /fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+    dependencies:
+      to-regex-range: 5.0.1
+    dev: true
 
   /finalhandler@1.3.1:
     resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
@@ -5092,6 +5558,19 @@ packages:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+    dev: true
+
+  /flat-cache@3.2.0:
+    resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    dependencies:
+      flatted: 3.3.3
+      keyv: 4.5.4
+      rimraf: 3.0.2
+    dev: true
+
+  /flatted@3.3.3:
+    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
     dev: true
 
   /fn.name@1.1.0:
@@ -5177,6 +5656,10 @@ packages:
       minipass: 3.3.6
     dev: false
 
+  /fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+    dev: true
+
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -5219,6 +5702,11 @@ packages:
     engines: {node: 6.* || 8.* || >= 10.*}
     dev: false
 
+  /get-east-asian-width@1.3.0:
+    resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
+    engines: {node: '>=18'}
+    dev: true
+
   /get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -5241,6 +5729,37 @@ packages:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  /get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
+    dev: true
+
+  /glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+    dependencies:
+      is-glob: 4.0.3
+    dev: true
+
+  /glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+    dependencies:
+      is-glob: 4.0.3
+    dev: true
+
+  /glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+    dev: true
+
   /global-agent@3.0.0:
     resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
     engines: {node: '>=10.0'}
@@ -5253,6 +5772,13 @@ packages:
       serialize-error: 7.0.1
     dev: false
 
+  /globals@13.24.0:
+    resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      type-fest: 0.20.2
+    dev: true
+
   /globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
@@ -5260,6 +5786,18 @@ packages:
       define-properties: 1.2.1
       gopd: 1.2.0
     dev: false
+
+  /globby@11.1.0:
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    engines: {node: '>=10'}
+    dependencies:
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.3.3
+      ignore: 5.3.2
+      merge2: 1.4.1
+      slash: 3.0.0
+    dev: true
 
   /google-logging-utils@0.0.2:
     resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
@@ -5272,6 +5810,10 @@ packages:
 
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+    dev: true
+
+  /graphemer@1.4.0:
+    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: true
 
   /has-flag@4.0.0:
@@ -5413,6 +5955,11 @@ packages:
       - supports-color
     dev: false
 
+  /human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
+    dev: true
+
   /husky@8.0.3:
     resolution: {integrity: sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==}
     engines: {node: '>=14'}
@@ -5436,6 +5983,19 @@ packages:
   /ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
+  /ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+    dev: true
+
+  /import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+    dev: true
+
   /import-in-the-middle@1.13.2:
     resolution: {integrity: sha512-Yjp9X7s2eHSXvZYQ0aye6UvwYPrVB5C2k47fuXjFKnYinAByaDZjh4t9MT2wEga9775n6WaIqyHnQhBxYtX2mg==}
     dependencies:
@@ -5448,6 +6008,19 @@ packages:
   /import-lazy@4.0.0:
     resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
     engines: {node: '>=8'}
+    dev: true
+
+  /imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+    dev: true
+
+  /inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
     dev: true
 
   /inherits@2.0.4:
@@ -5481,10 +6054,27 @@ packages:
     dependencies:
       hasown: 2.0.2
 
+  /is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
     dev: false
+
+  /is-fullwidth-code-point@4.0.0:
+    resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /is-fullwidth-code-point@5.0.0:
+    resolution: {integrity: sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==}
+    engines: {node: '>=18'}
+    dependencies:
+      get-east-asian-width: 1.3.0
+    dev: true
 
   /is-generator-function@1.1.0:
     resolution: {integrity: sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==}
@@ -5496,12 +6086,29 @@ packages:
       safe-regex-test: 1.1.0
     dev: true
 
+  /is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-extglob: 2.1.1
+    dev: true
+
   /is-nan@1.3.2:
     resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.8
       define-properties: 1.2.1
+    dev: true
+
+  /is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+    dev: true
+
+  /is-path-inside@3.0.3:
+    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
+    engines: {node: '>=8'}
     dev: true
 
   /is-promise@4.0.0:
@@ -5523,6 +6130,11 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
+  /is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: true
+
   /is-typed-array@1.1.15:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
@@ -5536,7 +6148,6 @@ packages:
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-    dev: false
 
   /isomorphic-timers-promises@1.0.1:
     resolution: {integrity: sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==}
@@ -5570,7 +6181,6 @@ packages:
     hasBin: true
     dependencies:
       argparse: 2.0.1
-    dev: false
 
   /jsmin@1.0.1:
     resolution: {integrity: sha512-OPuL5X/bFKgVdMvEIX3hnpx3jbVpFCrEM8pKPXjFkZUqg521r41ijdyTz7vACOhW6o1neVlcLyd+wkbK5fNHRg==}
@@ -5584,6 +6194,10 @@ packages:
       bignumber.js: 9.3.0
     dev: false
 
+  /json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+    dev: true
+
   /json-schema-to-zod@2.6.1:
     resolution: {integrity: sha512-uiHmWH21h9FjKJkRBntfVGTLpYlCZ1n98D0izIlByqQLqpmkQpNTBtfbdP04Na6+43lgsvrShFh2uWLkQDKJuQ==}
     hasBin: true
@@ -5591,7 +6205,6 @@ packages:
 
   /json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
-    dev: false
 
   /json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -5608,6 +6221,10 @@ packages:
   /json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
     dev: false
+
+  /json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+    dev: true
 
   /json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
@@ -5641,6 +6258,12 @@ packages:
       walker: 1.0.8
     dev: false
 
+  /keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+    dependencies:
+      json-buffer: 3.0.1
+    dev: true
+
   /kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
     dev: true
@@ -5648,6 +6271,14 @@ packages:
   /kuler@2.0.0:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
     dev: false
+
+  /levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+    dev: true
 
   /libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
@@ -5665,6 +6296,42 @@ packages:
       '@libsql/linux-x64-musl': 0.4.7
       '@libsql/win32-x64-msvc': 0.4.7
     dev: false
+
+  /lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+    dev: true
+
+  /lint-staged@15.5.2:
+    resolution: {integrity: sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==}
+    engines: {node: '>=18.12.0'}
+    hasBin: true
+    dependencies:
+      chalk: 5.4.1
+      commander: 13.1.0
+      debug: 4.4.1
+      execa: 8.0.1
+      lilconfig: 3.1.3
+      listr2: 8.3.3
+      micromatch: 4.0.8
+      pidtree: 0.6.0
+      string-argv: 0.3.2
+      yaml: 2.8.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /listr2@8.3.3:
+    resolution: {integrity: sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      cli-truncate: 4.0.0
+      colorette: 2.0.20
+      eventemitter3: 5.0.1
+      log-update: 6.1.0
+      rfdc: 1.4.1
+      wrap-ansi: 9.0.0
+    dev: true
 
   /local-pkg@1.1.1:
     resolution: {integrity: sha512-WunYko2W1NcdfAFpuLUoucsgULmgDBRkdxHxWQ7mK0cQqwPiy8E1enjuRBrhLtZkB5iScJ1XIPdhVEFK8aOLSg==}
@@ -5690,8 +6357,23 @@ packages:
     resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
     dev: false
 
+  /lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+    dev: true
+
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    dev: true
+
+  /log-update@6.1.0:
+    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
+    engines: {node: '>=18'}
+    dependencies:
+      ansi-escapes: 7.0.0
+      cli-cursor: 5.0.0
+      slice-ansi: 7.1.0
+      strip-ansi: 7.1.0
+      wrap-ansi: 9.0.0
     dev: true
 
   /logform@2.7.0:
@@ -5773,10 +6455,27 @@ packages:
     engines: {node: '>=18'}
     dev: false
 
+  /merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+    dev: true
+
+  /merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+    dev: true
+
   /methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
     dev: false
+
+  /micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.1
+    dev: true
 
   /miller-rabin@4.0.1:
     resolution: {integrity: sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==}
@@ -5816,6 +6515,16 @@ packages:
     hasBin: true
     dev: false
 
+  /mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+    dev: true
+
   /minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
     dev: true
@@ -5828,6 +6537,19 @@ packages:
     resolution: {integrity: sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==}
     dependencies:
       brace-expansion: 1.1.11
+    dev: true
+
+  /minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+    dependencies:
+      brace-expansion: 1.1.11
+    dev: true
+
+  /minimatch@9.0.3:
+    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
     dev: true
 
   /minimatch@9.0.5:
@@ -5918,6 +6640,10 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  /natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+    dev: true
+
   /negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
@@ -5988,6 +6714,13 @@ packages:
       vm-browserify: 1.1.2
     dev: true
 
+  /npm-run-path@5.3.0:
+    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      path-key: 4.0.0
+    dev: true
+
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -6037,13 +6770,26 @@ packages:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
-    dev: false
 
   /one-time@1.0.0:
     resolution: {integrity: sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==}
     dependencies:
       fn.name: 1.1.0
     dev: false
+
+  /onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      mimic-fn: 4.0.0
+    dev: true
+
+  /onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      mimic-function: 5.0.1
+    dev: true
 
   /onnxruntime-common@1.21.0:
     resolution: {integrity: sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==}
@@ -6062,6 +6808,18 @@ packages:
   /openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
     dev: false
+
+  /optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+    dev: true
 
   /os-browserify@0.3.0:
     resolution: {integrity: sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==}
@@ -6083,6 +6841,13 @@ packages:
 
   /pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+    dev: true
+
+  /parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+    dependencies:
+      callsites: 3.1.0
     dev: true
 
   /parse-asn1@5.1.7:
@@ -6111,10 +6876,19 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
-    dev: false
+
+  /path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+    dev: true
 
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -6127,6 +6901,11 @@ packages:
     resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
     engines: {node: '>=16'}
     dev: false
+
+  /path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
+    dev: true
 
   /pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -6175,6 +6954,12 @@ packages:
   /picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
+    dev: true
+
+  /pidtree@0.6.0:
+    resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
+    engines: {node: '>=0.10'}
+    hasBin: true
     dev: true
 
   /pino-abstract-transport@2.0.0:
@@ -6286,6 +7071,11 @@ packages:
     dependencies:
       xtend: 4.0.2
     dev: false
+
+  /prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+    dev: true
 
   /prettier@3.5.3:
     resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
@@ -6404,6 +7194,10 @@ packages:
     engines: {node: '>=0.4.x'}
     dev: true
 
+  /queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+    dev: true
+
   /quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
     dev: false
@@ -6513,6 +7307,11 @@ packages:
       - supports-color
     dev: false
 
+  /resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+    dev: true
+
   /resolve@1.22.10:
     resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
     engines: {node: '>= 0.4'}
@@ -6521,6 +7320,31 @@ packages:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  /restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
+    dev: true
+
+  /reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+    dev: true
+
+  /rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+    dev: true
+
+  /rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+    dependencies:
+      glob: 7.2.3
+    dev: true
 
   /ripemd160@2.0.2:
     resolution: {integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==}
@@ -6605,6 +7429,12 @@ packages:
       - supports-color
     dev: false
 
+  /run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+    dependencies:
+      queue-microtask: 1.2.3
+    dev: true
+
   /safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
     dev: true
@@ -6650,7 +7480,6 @@ packages:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
     engines: {node: '>=10'}
     hasBin: true
-    dev: false
 
   /send@0.19.0:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
@@ -6756,12 +7585,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       shebang-regex: 3.0.0
-    dev: false
 
   /shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
-    dev: false
 
   /shimmer@1.2.1:
     resolution: {integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==}
@@ -6807,11 +7634,37 @@ packages:
     resolution: {integrity: sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==}
     dev: false
 
+  /signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+    dev: true
+
   /simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
     dependencies:
       is-arrayish: 0.3.2
     dev: false
+
+  /slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /slice-ansi@5.0.0:
+    resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-styles: 6.2.1
+      is-fullwidth-code-point: 4.0.0
+    dev: true
+
+  /slice-ansi@7.1.0:
+    resolution: {integrity: sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==}
+    engines: {node: '>=18'}
+    dependencies:
+      ansi-styles: 6.2.1
+      is-fullwidth-code-point: 5.0.0
+    dev: true
 
   /sonic-boom@4.2.0:
     resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
@@ -6886,6 +7739,15 @@ packages:
       strip-ansi: 6.0.1
     dev: false
 
+  /string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      emoji-regex: 10.4.0
+      get-east-asian-width: 1.3.0
+      strip-ansi: 7.1.0
+    dev: true
+
   /string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
     dependencies:
@@ -6902,7 +7764,18 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       ansi-regex: 5.0.1
-    dev: false
+
+  /strip-ansi@7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-regex: 6.1.0
+    dev: true
+
+  /strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+    dev: true
 
   /strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -6968,6 +7841,10 @@ packages:
     resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
     dev: false
 
+  /text-table@0.2.0:
+    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+    dev: true
+
   /thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
     dependencies:
@@ -6991,9 +7868,24 @@ packages:
     engines: {node: '>= 0.2.0'}
     dev: false
 
+  /tinyglobby@0.2.14:
+    resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      fdir: 6.4.6(picomatch@4.0.2)
+      picomatch: 4.0.2
+    dev: true
+
   /tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
     dev: false
+
+  /to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+    dependencies:
+      is-number: 7.0.0
+    dev: true
 
   /toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -7012,6 +7904,15 @@ packages:
     resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
     engines: {node: '>= 14.0.0'}
     dev: false
+
+  /ts-api-utils@1.4.3(typescript@5.8.3):
+    resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      typescript: '>=4.2.0'
+    dependencies:
+      typescript: 5.8.3
+    dev: true
 
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
@@ -7085,10 +7986,22 @@ packages:
       turbo-windows-arm64: 1.13.4
     dev: true
 
+  /type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      prelude-ls: 1.2.1
+    dev: true
+
   /type-fest@0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
     dev: false
+
+  /type-fest@0.20.2:
+    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
+    engines: {node: '>=10'}
+    dev: true
 
   /type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -7237,6 +8150,18 @@ packages:
       - rollup
     dev: true
 
+  /vite-plugin-node-polyfills@0.23.0(rollup@4.41.0)(vite@6.3.5):
+    resolution: {integrity: sha512-4n+Ys+2bKHQohPBKigFlndwWQ5fFKwaGY6muNDMTb0fSQLyBzS+jjUNRZG9sKF0S/Go4ApG6LFnUGopjkILg3w==}
+    peerDependencies:
+      vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
+    dependencies:
+      '@rollup/plugin-inject': 5.0.5(rollup@4.41.0)
+      node-stdlib-browser: 1.3.1
+      vite: 6.3.5(@types/node@22.15.21)
+    transitivePeerDependencies:
+      - rollup
+    dev: true
+
   /vite-plugin-node@5.0.1(vite@5.4.19):
     resolution: {integrity: sha512-xdR4UW1h2ZM1wBf4pjwzuty/mX6F/GViB8h1iqOpxr81pa5OuWb3IJghl66v4e7Srsi2p5o22n9G7G46FeZK9Q==}
     peerDependencies:
@@ -7250,6 +8175,23 @@ packages:
       chalk: 4.1.2
       debug: 4.4.1
       vite: 5.4.19(@types/node@22.15.21)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /vite-plugin-node@5.0.1(vite@6.3.5):
+    resolution: {integrity: sha512-xdR4UW1h2ZM1wBf4pjwzuty/mX6F/GViB8h1iqOpxr81pa5OuWb3IJghl66v4e7Srsi2p5o22n9G7G46FeZK9Q==}
+    peerDependencies:
+      '@swc/core': ^1.7.26
+      vite: ^6.2.2
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 4.2.1
+      chalk: 4.1.2
+      debug: 4.4.1
+      vite: 6.3.5(@types/node@22.15.21)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7289,6 +8231,57 @@ packages:
       esbuild: 0.21.5
       postcss: 8.5.3
       rollup: 4.41.0
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /vite@6.3.5(@types/node@22.15.21):
+    resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+    dependencies:
+      '@types/node': 22.15.21
+      esbuild: 0.25.4
+      fdir: 6.4.6(picomatch@4.0.2)
+      picomatch: 4.0.2
+      postcss: 8.5.3
+      rollup: 4.41.0
+      tinyglobby: 0.2.14
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
@@ -7342,7 +8335,6 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
-    dev: false
 
   /winston-transport@4.9.0:
     resolution: {integrity: sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==}
@@ -7370,6 +8362,11 @@ packages:
       winston-transport: 4.9.0
     dev: false
 
+  /word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -7379,9 +8376,17 @@ packages:
       strip-ansi: 6.0.1
     dev: false
 
+  /wrap-ansi@9.0.0:
+    resolution: {integrity: sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==}
+    engines: {node: '>=18'}
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 7.2.0
+      strip-ansi: 7.1.0
+    dev: true
+
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-    dev: false
 
   /wrench@1.3.9:
     resolution: {integrity: sha512-srTJQmLTP5YtW+F5zDuqjMEZqLLr/eJOZfDI5ibfPfRMeDh3oBUefAscuH0q5wBKE339ptH/S/0D18ZkfOfmKQ==}
@@ -7422,6 +8427,12 @@ packages:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
     dev: false
+
+  /yaml@2.8.0:
+    resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+    dev: true
 
   /yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}

--- a/sdk/lib/adapters/aisdk.ts
+++ b/sdk/lib/adapters/aisdk.ts
@@ -4,8 +4,8 @@
  */
 
 import { tool } from "ai";
-import { 
-  createActionSchema, 
+import {
+  createActionSchema,
   updateActionSchema,
   executeAmpersandWrite,
   CreateParams,
@@ -40,14 +40,13 @@ import {
   StartOAuthOutputType,
   getOAuthURL,
 } from "./common";
-import { z } from "zod";
 import { callAmpersandProxy } from "./ampersand/core/request";
 
 /**
  * Creates a new record in the Ampersand system using Vercel AI SDK.
  * @remarks
  * Requires the 'ai' package to be installed via npm.
- * 
+ *
  * @param objectName - The name of the object to create
  * @param type - The type of operation (create)
  * @param record - The record data to write
@@ -58,7 +57,13 @@ import { callAmpersandProxy } from "./ampersand/core/request";
 export const createRecord = tool({
   description: createRecordToolDescription,
   parameters: createActionSchema,
-  execute: async ({ objectName, type, record, groupRef, associations }: CreateParams) => {
+  execute: async ({
+    objectName,
+    type,
+    record,
+    groupRef,
+    associations,
+  }: CreateParams) => {
     const result = await executeAmpersandWrite({
       objectName,
       type,
@@ -77,7 +82,7 @@ export const createRecord = tool({
 /**
  * Updates an existing record in the Ampersand system using Vercel AI SDK.
  * @remarks
- * 
+ *
  * @param objectName - The name of the object to update
  * @param type - The type of operation (update)
  * @param record - The updated record data
@@ -88,7 +93,13 @@ export const createRecord = tool({
 export const updateRecord = tool({
   description: updateRecordToolDescription,
   parameters: updateActionSchema,
-  execute: async ({ objectName, type, record, groupRef, associations }: UpdateParams) => {
+  execute: async ({
+    objectName,
+    type,
+    record,
+    groupRef,
+    associations,
+  }: UpdateParams) => {
     const result = await executeAmpersandWrite({
       objectName,
       type,
@@ -112,7 +123,9 @@ export const updateRecord = tool({
 export const checkConnection = tool({
   description: checkConnectionToolDescription,
   parameters: checkConnectionInputSchema,
-  execute: async (params: CheckConnectionInputType): Promise<CheckConnectionOutputType> => {
+  execute: async (
+    params: CheckConnectionInputType,
+  ): Promise<CheckConnectionOutputType> => {
     const { provider } = params;
     const res = await checkConnectionHelper({ provider });
     return res;
@@ -129,9 +142,15 @@ export const checkConnection = tool({
 export const createInstallation = tool({
   description: createInstallationToolDescription,
   parameters: createInstallationInputSchema,
-  execute: async (params: CreateInstallationInputType): Promise<CreateInstallationOutputType> => {
+  execute: async (
+    params: CreateInstallationInputType,
+  ): Promise<CreateInstallationOutputType> => {
     const { provider, connectionId, groupRef } = params;
-    const res = await createInstallationHelper({ provider, connectionId, groupRef: process.env.AMPERSAND_GROUP_REF || groupRef });
+    const res = await createInstallationHelper({
+      provider,
+      connectionId,
+      groupRef: process.env.AMPERSAND_GROUP_REF || groupRef,
+    });
     return res;
   },
 });
@@ -144,7 +163,9 @@ export const createInstallation = tool({
 export const checkInstallation = tool({
   description: checkInstallationToolDescription,
   parameters: checkInstallationInputSchema,
-  execute: async (params: CheckInstallationInputType): Promise<CheckInstallationOutputType> => {
+  execute: async (
+    params: CheckInstallationInputType,
+  ): Promise<CheckInstallationOutputType> => {
     const { provider } = params;
     const res = await checkInstallationHelper({ provider });
     return res;
@@ -161,11 +182,19 @@ export const checkInstallation = tool({
 export const startOAuth = tool({
   description: startOAuthToolDescription,
   parameters: startOAuthInputSchema,
-  execute: async (params: StartOAuthInputType): Promise<StartOAuthOutputType> => {
+  execute: async (
+    params: StartOAuthInputType,
+  ): Promise<StartOAuthOutputType> => {
     const { provider, groupRef, consumerRef } = params;
     const projectId = process.env.AMPERSAND_PROJECT_ID || "";
     const apiKey = process.env.AMPERSAND_API_KEY || "";
-    const url = await getOAuthURL({ provider, groupRef: process.env.AMPERSAND_GROUP_REF || groupRef, consumerRef, projectId, apiKey });
+    const url = await getOAuthURL({
+      provider,
+      groupRef: process.env.AMPERSAND_GROUP_REF || groupRef,
+      consumerRef,
+      projectId,
+      apiKey,
+    });
     return { url };
   },
 });
@@ -183,8 +212,17 @@ export const startOAuth = tool({
 export const sendRequest = tool({
   description: sendRequestToolDescription,
   parameters: sendRequestInputSchema,
-  execute: async (params: SendRequestInputType): Promise<SendRequestOutputType> => {
-    const { provider, body, endpoint, method, headers = {}, installationId } = params;
+  execute: async (
+    params: SendRequestInputType,
+  ): Promise<SendRequestOutputType> => {
+    const {
+      provider,
+      body,
+      endpoint,
+      method,
+      headers = {},
+      installationId,
+    } = params;
     const projectId = process.env.AMPERSAND_PROJECT_ID || "";
     const apiKey = process.env.AMPERSAND_API_KEY || "";
     const integrationName = process.env.AMPERSAND_INTEGRATION_NAME || "";
@@ -213,7 +251,9 @@ export const sendRequest = tool({
 export const sendReadRequest = tool({
   description: sendReadRequestToolDescription,
   parameters: sendReadRequestInputSchema,
-  execute: async (params: SendReadRequestInputType): Promise<SendRequestOutputType> => {
+  execute: async (
+    params: SendReadRequestInputType,
+  ): Promise<SendRequestOutputType> => {
     const { provider, endpoint, headers = {}, installationId } = params;
     const projectId = process.env.AMPERSAND_PROJECT_ID || "";
     const apiKey = process.env.AMPERSAND_API_KEY || "";

--- a/sdk/lib/adapters/ampersand/core/connection.ts
+++ b/sdk/lib/adapters/ampersand/core/connection.ts
@@ -50,4 +50,4 @@ export async function checkConnectionHelper({
     console.error("[Ampersand] Error while checking connection:", error);
     throw error;
   }
-} 
+}

--- a/sdk/lib/adapters/ampersand/core/installation.ts
+++ b/sdk/lib/adapters/ampersand/core/installation.ts
@@ -49,11 +49,17 @@ export async function checkInstallationHelper({
     });
 
     // @ts-ignore – Filter by provider (Ampersand lower-cases internally)
-    const filtered = installations.filter((inst: any) => inst.connection?.provider === provider.toLowerCase());
+    const filtered = installations.filter(
+      (inst: any) => inst.connection?.provider === provider.toLowerCase(),
+    );
 
     if (filtered.length > 0) {
       const installation = filtered[0];
-      return { found: true, installationId: installation.id, data: installation };
+      return {
+        found: true,
+        installationId: installation.id,
+        data: installation,
+      };
     }
 
     return { found: false };
@@ -109,15 +115,31 @@ export async function createInstallationHelper({
 /**
  * Ensure an installation exists, creating one if necessary. Returns the installationId.
  */
-export async function ensureInstallationExists(provider: string, apiKey: string, projectId: string, integrationName: string): Promise<string> {
+export async function ensureInstallationExists(
+  provider: string,
+  apiKey: string,
+  projectId: string,
+  integrationName: string,
+): Promise<string> {
   // First, verify a connection exists and grab its identifiers
-  const connection = await checkConnectionHelper({ provider, apiKey, projectId });
+  const connection = await checkConnectionHelper({
+    provider,
+    apiKey,
+    projectId,
+  });
   if (!connection.found || !connection.connectionId || !connection.groupRef) {
-    throw new Error(`No existing connections found for ${provider}. Please connect using OAuth.`);
+    throw new Error(
+      `No existing connections found for ${provider}. Please connect using OAuth.`,
+    );
   }
 
   // Check existing installation list
-  const installation = await checkInstallationHelper({ provider, apiKey, projectId, integrationName });
+  const installation = await checkInstallationHelper({
+    provider,
+    apiKey,
+    projectId,
+    integrationName,
+  });
   if (installation.found && installation.installationId) {
     return installation.installationId;
   }
@@ -137,4 +159,4 @@ export async function ensureInstallationExists(provider: string, apiKey: string,
   }
 
   return createRes.installationId;
-} 
+}

--- a/sdk/lib/adapters/ampersand/core/oauth.ts
+++ b/sdk/lib/adapters/ampersand/core/oauth.ts
@@ -7,7 +7,13 @@
  * @param apiKey - API key for authentication (required)
  * @returns The OAuth URL as a string
  */
-export async function getOAuthURL({ provider, groupRef, consumerRef, projectId, apiKey }: {
+export async function getOAuthURL({
+  provider,
+  groupRef,
+  consumerRef,
+  projectId,
+  apiKey,
+}: {
   provider: string;
   groupRef?: string;
   consumerRef?: string;
@@ -22,6 +28,9 @@ export async function getOAuthURL({ provider, groupRef, consumerRef, projectId, 
     },
     body: JSON.stringify({ provider, consumerRef, groupRef, projectId }),
   };
-  const response = await fetch("https://api.withampersand.com/v1/oauth-connect", options);
+  const response = await fetch(
+    "https://api.withampersand.com/v1/oauth-connect",
+    options,
+  );
   return response.text();
 }

--- a/sdk/lib/adapters/ampersand/core/request.ts
+++ b/sdk/lib/adapters/ampersand/core/request.ts
@@ -46,7 +46,7 @@ export async function callAmpersandProxy({
   }
   const response = await fetch(
     `https://proxy.withampersand.com/${endpoint}`,
-    fetchOptions
+    fetchOptions,
   );
   const responseData = await response.json();
   return {

--- a/sdk/lib/adapters/ampersand/core/write.ts
+++ b/sdk/lib/adapters/ampersand/core/write.ts
@@ -1,5 +1,8 @@
 import { Ampersand } from "@amp-labs/sdk-node-write";
-import { WriteRecordsResponse, WriteRecordsSyncWriteResponseSuccess } from "@amp-labs/sdk-node-write/models/operations";
+import {
+  WriteRecordsResponse,
+  WriteRecordsSyncWriteResponseSuccess,
+} from "@amp-labs/sdk-node-write/models/operations";
 import { WriteResponse } from "../types";
 import * as Sentry from "@sentry/node";
 interface WriteParams {
@@ -33,7 +36,7 @@ export async function executeAmpersandWrite({
     const writeSDK = new Ampersand({
       apiKeyHeader: apiKey,
     });
-    
+
     const writeData = {
       projectIdOrName: projectId,
       integrationId: integrationName,
@@ -47,11 +50,12 @@ export async function executeAmpersandWrite({
     };
 
     const data: WriteRecordsResponse = await writeSDK.write.records(writeData);
-    
+
     return {
       success: true,
       status: "success",
-      recordId: (data as WriteRecordsSyncWriteResponseSuccess)?.result?.recordId || "",
+      recordId:
+        (data as WriteRecordsSyncWriteResponseSuccess)?.result?.recordId || "",
       response: data,
     };
   } catch (error) {
@@ -64,4 +68,4 @@ export async function executeAmpersandWrite({
       response: error,
     };
   }
-} 
+}

--- a/sdk/lib/adapters/ampersand/schemas/index.ts
+++ b/sdk/lib/adapters/ampersand/schemas/index.ts
@@ -1,14 +1,22 @@
 import { z } from "zod";
 
 // Tool descriptions
-export const createRecordToolDescription = "Create a record in a SaaS platform (e.g. create a new Contact in Salesforce)";
-export const updateRecordToolDescription = "Update a record in a SaaS platform (e.g. update a contact's email address in Hubspot)";
-export const checkConnectionToolDescription = "Check if there is an active connection for a provider on Ampersand";
-export const createInstallationToolDescription = "Create a new installation for a provider on Ampersand";
-export const checkInstallationToolDescription = "Check if an installation exists for a provider on Ampersand";
-export const startOAuthToolDescription = "Connect to a SaaS provider using the Ampersand OAuth flow and obtain a connection URL";
-export const sendRequestToolDescription = "Call provider APIs via the Ampersand sendRequest tool";
-export const sendReadRequestToolDescription = "Call provider APIs via the Ampersand sendReadRequest tool (GET only)";
+export const createRecordToolDescription =
+  "Create a record in a SaaS platform (e.g. create a new Contact in Salesforce)";
+export const updateRecordToolDescription =
+  "Update a record in a SaaS platform (e.g. update a contact's email address in Hubspot)";
+export const checkConnectionToolDescription =
+  "Check if there is an active connection for a provider on Ampersand";
+export const createInstallationToolDescription =
+  "Create a new installation for a provider on Ampersand";
+export const checkInstallationToolDescription =
+  "Check if an installation exists for a provider on Ampersand";
+export const startOAuthToolDescription =
+  "Connect to a SaaS provider using the Ampersand OAuth flow and obtain a connection URL";
+export const sendRequestToolDescription =
+  "Call provider APIs via the Ampersand sendRequest tool";
+export const sendReadRequestToolDescription =
+  "Call provider APIs via the Ampersand sendReadRequest tool (GET only)";
 
 // Schema for associations
 export const associationsSchema = z
@@ -21,25 +29,31 @@ export const associationsSchema = z
         z.object({
           associationCategory: z.string(),
           associationTypeId: z.number(),
-        })
+        }),
       ),
-    })
+    }),
   )
   .optional()
   .describe("Optional associations for the record");
 
 export const providerSchema = z
   .string()
-  .describe(`The SaaS API provider to connect to. Always use camelCase (e.g. "monday", "hubspot", "salesforce").`);
+  .describe(
+    `The SaaS API provider to connect to. Always use camelCase (e.g. "monday", "hubspot", "salesforce").`,
+  );
 
 export const endpointSchema = z
   .string()
-  .describe(`The endpoint to call on the provider, without the base URL, and including the version. (e.g. If the full URL is "my-workspace.my.salesforce.com/services/data/v60.0/sobjects/Account", the endpoint is "v60.0/sobjects/Account")`);
+  .describe(
+    `The endpoint to call on the provider, without the base URL, and including the version. (e.g. If the full URL is "my-workspace.my.salesforce.com/services/data/v60.0/sobjects/Account", the endpoint is "v60.0/sobjects/Account")`,
+  );
 
 export const installationIdSchema = z
   .string()
   .optional()
-  .describe(`The ID of the installation. If you don't know it, use the check-installation tool.`);
+  .describe(
+    `The ID of the installation. If you don't know it, use the check-installation tool.`,
+  );
 
 // Base schema for write operations
 export const baseWriteSchema = {
@@ -52,18 +66,14 @@ export const baseWriteSchema = {
 export const createActionSchema = z.object({
   ...baseWriteSchema,
   type: z.enum(["create"]).describe("The type of write operation"),
-  groupRef: z
-    .string()
-    .describe("The group reference for the write operation"),
+  groupRef: z.string().describe("The group reference for the write operation"),
 });
 
 // Update operation schema
 export const updateActionSchema = z.object({
   ...baseWriteSchema,
   type: z.enum(["update"]).describe("The type of write operation"),
-  groupRef: z
-    .string()
-    .describe("The group reference for the write operation"),
+  groupRef: z.string().describe("The group reference for the write operation"),
 });
 
 // Common output schema
@@ -114,7 +124,10 @@ export const checkInstallationOutputSchema = z.object({
 export const startOAuthInputSchema = z.object({
   provider: providerSchema,
   groupRef: z.string().optional().describe("The group reference for Ampersand"),
-  consumerRef: z.string().optional().describe("The consumer reference for Ampersand"),
+  consumerRef: z
+    .string()
+    .optional()
+    .describe("The consumer reference for Ampersand"),
 });
 
 export const startOAuthOutputSchema = z.object({
@@ -127,7 +140,10 @@ export const sendRequestInputSchema = z.object({
   body: z.record(z.any()).optional().describe("Body of the request"),
   endpoint: endpointSchema,
   method: z.string().describe("HTTP method to use"),
-  headers: z.record(z.string()).optional().describe("Headers to send with the request"),
+  headers: z
+    .record(z.string())
+    .optional()
+    .describe("Headers to send with the request"),
   installationId: installationIdSchema,
 });
 
@@ -139,7 +155,10 @@ export const sendRequestOutputSchema = z.object({
 export const sendReadRequestInputSchema = z.object({
   provider: providerSchema,
   endpoint: endpointSchema,
-  headers: z.record(z.string()).optional().describe("Headers to send with the request"),
+  headers: z
+    .record(z.string())
+    .optional()
+    .describe("Headers to send with the request"),
   installationId: installationIdSchema,
 });
 
@@ -149,14 +168,28 @@ export type ProviderType = z.infer<typeof providerSchema>;
 export type CreateActionType = z.infer<typeof createActionSchema>;
 export type UpdateActionType = z.infer<typeof updateActionSchema>;
 export type WriteOutputType = z.infer<typeof writeOutputSchema>;
-export type CheckConnectionInputType = z.infer<typeof checkConnectionInputSchema>;
-export type CheckConnectionOutputType = z.infer<typeof checkConnectionOutputSchema>;
-export type CreateInstallationInputType = z.infer<typeof createInstallationInputSchema>;
-export type CreateInstallationOutputType = z.infer<typeof createInstallationOutputSchema>;
-export type CheckInstallationInputType = z.infer<typeof checkInstallationInputSchema>;
-export type CheckInstallationOutputType = z.infer<typeof checkInstallationOutputSchema>;
+export type CheckConnectionInputType = z.infer<
+  typeof checkConnectionInputSchema
+>;
+export type CheckConnectionOutputType = z.infer<
+  typeof checkConnectionOutputSchema
+>;
+export type CreateInstallationInputType = z.infer<
+  typeof createInstallationInputSchema
+>;
+export type CreateInstallationOutputType = z.infer<
+  typeof createInstallationOutputSchema
+>;
+export type CheckInstallationInputType = z.infer<
+  typeof checkInstallationInputSchema
+>;
+export type CheckInstallationOutputType = z.infer<
+  typeof checkInstallationOutputSchema
+>;
 export type StartOAuthInputType = z.infer<typeof startOAuthInputSchema>;
 export type StartOAuthOutputType = z.infer<typeof startOAuthOutputSchema>;
 export type SendRequestInputType = z.infer<typeof sendRequestInputSchema>;
 export type SendRequestOutputType = z.infer<typeof sendRequestOutputSchema>;
-export type SendReadRequestInputType = z.infer<typeof sendReadRequestInputSchema>;
+export type SendReadRequestInputType = z.infer<
+  typeof sendReadRequestInputSchema
+>;

--- a/sdk/lib/adapters/ampersand/types/index.ts
+++ b/sdk/lib/adapters/ampersand/types/index.ts
@@ -32,4 +32,4 @@ export type WriteResponse = {
   status: string;
   recordId: string;
   response: any;
-}; 
+};

--- a/sdk/lib/adapters/mastra.ts
+++ b/sdk/lib/adapters/mastra.ts
@@ -42,8 +42,6 @@ import {
   startOAuthToolDescription,
   startOAuthInputSchema,
   startOAuthOutputSchema,
-  StartOAuthInputType,
-  StartOAuthOutputType,
   getOAuthURL,
 } from "./common";
 import { RuntimeContext } from "@mastra/core/runtime-context";
@@ -79,8 +77,7 @@ export const createRecord = createTool({
     context: CreateActionType;
     runtimeContext: RuntimeContext;
   }): Promise<WriteOutputType> => {
-    const { objectName, type, record, groupRef, associations } =
-      context;
+    const { objectName, type, record, groupRef, associations } = context;
     const result = await executeAmpersandWrite({
       objectName,
       type,
@@ -126,8 +123,7 @@ export const updateRecord = createTool({
     context: UpdateActionType;
     runtimeContext: RuntimeContext;
   }): Promise<WriteOutputType> => {
-    const { objectName, type, record, groupRef, associations } =
-      context;
+    const { objectName, type, record, groupRef, associations } = context;
     const result = await executeAmpersandWrite({
       objectName,
       type,
@@ -269,7 +265,10 @@ export const startOAuth = createTool({
     const apiKey = process.env.AMPERSAND_API_KEY || "";
     const url = await getOAuthURL({
       provider,
-      groupRef: runtimeContext.get("AMPERSAND_GROUP_REF") || process.env.AMPERSAND_GROUP_REF || groupRef,
+      groupRef:
+        runtimeContext.get("AMPERSAND_GROUP_REF") ||
+        process.env.AMPERSAND_GROUP_REF ||
+        groupRef,
       consumerRef,
       projectId,
       apiKey,
@@ -311,9 +310,18 @@ export const sendRequest = createTool({
       headers = {},
       installationId,
     } = context;
-    const apiKey = String(runtimeContext.get("AMPERSAND_API_KEY")) || String(process.env.AMPERSAND_API_KEY) || "";
-    const projectId = String(runtimeContext.get("AMPERSAND_PROJECT_ID")) || String(process.env.AMPERSAND_PROJECT_ID) || "";
-    const integrationName = String(runtimeContext.get("AMPERSAND_INTEGRATION_NAME")) || String(process.env.AMPERSAND_INTEGRATION_NAME) || "";
+    const apiKey =
+      String(runtimeContext.get("AMPERSAND_API_KEY")) ||
+      String(process.env.AMPERSAND_API_KEY) ||
+      "";
+    const projectId =
+      String(runtimeContext.get("AMPERSAND_PROJECT_ID")) ||
+      String(process.env.AMPERSAND_PROJECT_ID) ||
+      "";
+    const integrationName =
+      String(runtimeContext.get("AMPERSAND_INTEGRATION_NAME")) ||
+      String(process.env.AMPERSAND_INTEGRATION_NAME) ||
+      "";
     return callAmpersandProxy({
       provider,
       endpoint,
@@ -343,9 +351,20 @@ export const sendReadRequest = createTool({
   outputSchema: sendRequestOutputSchema,
   execute: async ({ context, runtimeContext }) => {
     const { provider, endpoint, headers = {}, installationId } = context;
-    const apiKey = (runtimeContext.get("AMPERSAND_API_KEY") ?? process.env.AMPERSAND_API_KEY)?.toString() || "";
-    const projectId = (runtimeContext.get("AMPERSAND_PROJECT_ID") ?? process.env.AMPERSAND_PROJECT_ID)?.toString() || "";
-    const integrationName = (runtimeContext.get("AMPERSAND_INTEGRATION_NAME") ?? process.env.AMPERSAND_INTEGRATION_NAME)?.toString() || "";
+    const apiKey =
+      (
+        runtimeContext.get("AMPERSAND_API_KEY") ?? process.env.AMPERSAND_API_KEY
+      )?.toString() || "";
+    const projectId =
+      (
+        runtimeContext.get("AMPERSAND_PROJECT_ID") ??
+        process.env.AMPERSAND_PROJECT_ID
+      )?.toString() || "";
+    const integrationName =
+      (
+        runtimeContext.get("AMPERSAND_INTEGRATION_NAME") ??
+        process.env.AMPERSAND_INTEGRATION_NAME
+      )?.toString() || "";
     return callAmpersandProxy({
       provider,
       endpoint,

--- a/sdk/lib/adapters/mcp.ts
+++ b/sdk/lib/adapters/mcp.ts
@@ -7,7 +7,7 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { z } from "zod";
 import * as Sentry from "@sentry/node";
 import {
-  providerSchema, 
+  providerSchema,
   associationsSchema,
   executeAmpersandWrite,
   checkConnectionInputSchema,
@@ -30,7 +30,6 @@ import {
   startOAuthToolDescription,
   startOAuthInputSchema,
   StartOAuthInputType,
-  StartOAuthOutputType,
   ensureInstallationExists,
 } from "./common";
 
@@ -49,7 +48,7 @@ type ClientSettings = {
 /**
  * Creates a write action tool for the MCP server.
  * This is a factory function that creates either a create or update tool based on the type parameter.
- * 
+ *
  * @param server - The MCP server instance
  * @param type - The type of write action ("create" or "update")
  * @param name - The name of the tool
@@ -59,7 +58,7 @@ export const createWriteActionTool = async (
   server: Server,
   type: "create" | "update",
   name: string,
-  settings: ClientSettings
+  settings: ClientSettings,
 ) => {
   // @ts-ignore
   return server.tool(
@@ -72,14 +71,18 @@ export const createWriteActionTool = async (
       record: z.record(z.any()).describe("The record data to write"),
       groupRef: z
         .string()
-        .describe("The group reference for the SaaS instance that should be written to"),
+        .describe(
+          "The group reference for the SaaS instance that should be written to",
+        ),
       associations: associationsSchema,
     },
-    async (params: CreateActionType | UpdateActionType): Promise<MCPResponse> => {
+    async (
+      params: CreateActionType | UpdateActionType,
+    ): Promise<MCPResponse> => {
       const { objectName, type, record, groupRef, associations } = params;
-      
+
       console.log(`[WRITE] about to perform ${type} operation`, params);
-      
+
       const result = await executeAmpersandWrite({
         objectName,
         type,
@@ -88,11 +91,17 @@ export const createWriteActionTool = async (
         associations,
         apiKey: settings.apiKey || process.env.AMPERSAND_API_KEY || "",
         projectId: settings.project || process.env.AMPERSAND_PROJECT_ID || "",
-        integrationName: settings.integrationName || process.env.AMPERSAND_INTEGRATION_NAME || "",
+        integrationName:
+          settings.integrationName ||
+          process.env.AMPERSAND_INTEGRATION_NAME ||
+          "",
       });
 
       if (result.success) {
-        console.log(`[WRITE] ${type} operation on provider succeeded:`, result.response);
+        console.log(
+          `[WRITE] ${type} operation on provider succeeded:`,
+          result.response,
+        );
         return {
           content: [
             {
@@ -120,17 +129,20 @@ export const createWriteActionTool = async (
           ],
         };
       }
-    }
+    },
   );
 };
 
 /**
  * Creates a connection checking tool for the MCP server.
- * 
+ *
  * @param server - The MCP server instance
  * @returns A configured MCP tool for checking provider connections
  */
-export const createCheckConnectionTool = async (server: Server, settings: ClientSettings) => {
+export const createCheckConnectionTool = async (
+  server: Server,
+  settings: ClientSettings,
+) => {
   // @ts-ignore
   return server.tool(
     "check-connection",
@@ -138,7 +150,11 @@ export const createCheckConnectionTool = async (server: Server, settings: Client
     checkConnectionInputSchema.shape,
     async (params: CheckConnectionInputType): Promise<MCPResponse> => {
       try {
-        const res = await checkConnectionHelper({ ...params, apiKey: settings.apiKey || process.env.AMPERSAND_API_KEY || "", projectId: settings.project || process.env.AMPERSAND_PROJECT_ID || "" });
+        const res = await checkConnectionHelper({
+          ...params,
+          apiKey: settings.apiKey || process.env.AMPERSAND_API_KEY || "",
+          projectId: settings.project || process.env.AMPERSAND_PROJECT_ID || "",
+        });
         if (res.found) {
           return {
             content: [
@@ -170,17 +186,20 @@ export const createCheckConnectionTool = async (server: Server, settings: Client
           ],
         };
       }
-    }
+    },
   );
 };
 
 /**
  * Creates an installation creation tool for the MCP server.
- * 
+ *
  * @param server - The MCP server instance
  * @returns A configured MCP tool for creating provider installations
  */
-export const createCreateInstallationTool = async (server: Server, settings: ClientSettings) => {
+export const createCreateInstallationTool = async (
+  server: Server,
+  settings: ClientSettings,
+) => {
   // @ts-ignore
   return server.tool(
     "create-installation",
@@ -188,7 +207,11 @@ export const createCreateInstallationTool = async (server: Server, settings: Cli
     createInstallationInputSchema.shape,
     async (params: CreateInstallationInputType): Promise<MCPResponse> => {
       try {
-        const res = await createInstallationHelper({ ...params, apiKey: settings.apiKey || process.env.AMPERSAND_API_KEY || "", projectId: settings.project || process.env.AMPERSAND_PROJECT_ID || "" });
+        const res = await createInstallationHelper({
+          ...params,
+          apiKey: settings.apiKey || process.env.AMPERSAND_API_KEY || "",
+          projectId: settings.project || process.env.AMPERSAND_PROJECT_ID || "",
+        });
         return {
           content: [
             {
@@ -202,21 +225,27 @@ export const createCreateInstallationTool = async (server: Server, settings: Cli
         return {
           isError: true,
           content: [
-            { type: "text", text: `Error creating installation: ${err instanceof Error ? err.message : err}` },
+            {
+              type: "text",
+              text: `Error creating installation: ${err instanceof Error ? err.message : err}`,
+            },
           ],
         };
       }
-    }
+    },
   );
 };
 
 /**
  * Creates an installation checking tool for the MCP server.
- * 
+ *
  * @param server - The MCP server instance
  * @returns A configured MCP tool for checking provider installations
  */
-export const createCheckInstallationTool = async (server: Server, settings: ClientSettings) => {
+export const createCheckInstallationTool = async (
+  server: Server,
+  settings: ClientSettings,
+) => {
   // @ts-ignore
   return server.tool(
     "check-installation",
@@ -224,51 +253,27 @@ export const createCheckInstallationTool = async (server: Server, settings: Clie
     checkInstallationInputSchema.shape,
     async (params: CheckInstallationInputType): Promise<MCPResponse> => {
       try {
-        const res = await checkInstallationHelper({ ...params, apiKey: settings.apiKey || process.env.AMPERSAND_API_KEY || "", projectId: settings.project || process.env.AMPERSAND_PROJECT_ID || "" });
+        const res = await checkInstallationHelper({
+          ...params,
+          apiKey: settings.apiKey || process.env.AMPERSAND_API_KEY || "",
+          projectId: settings.project || process.env.AMPERSAND_PROJECT_ID || "",
+        });
         if (res.found) {
           return {
             content: [
-              { type: "text", text: `Installation found for ${params.provider} ID: ${res.installationId}` },
+              {
+                type: "text",
+                text: `Installation found for ${params.provider} ID: ${res.installationId}`,
+              },
             ],
           };
         }
-        return { content: [ { type: "text", text: `No installation found for ${params.provider}` } ] };
-      } catch (err) {
-        Sentry.captureException(err);
-        return { isError: true, content: [ { type: "text", text: `Error: ${err instanceof Error ? err.message : err}` } ] };
-      }
-    }
-  );
-};
-
-/**
- * Creates an OAuth tool for the MCP server.
- * 
- * @param server - The MCP server instance
- * @returns A configured MCP tool for handling OAuth flows
- */
-export const createStartOAuthTool = async (server: Server, settings: ClientSettings) => {
-  // @ts-ignore
-  return server.tool(
-    "start-oauth",
-    startOAuthToolDescription,
-    startOAuthInputSchema.shape,
-    async (params: StartOAuthInputType): Promise<MCPResponse> => {
-      const { provider, groupRef, consumerRef } = params;
-      const finalConsumerRef = consumerRef || Math.random().toString(36).substring(2, 15);
-      const finalGroupRef = settings?.groupRef || groupRef || "";
-      const projectId = settings?.project || process.env.AMPERSAND_PROJECT_ID || "";
-      let url = "";
-      try {
-        const response = await fetch("https://api.withampersand.com/v1/oauth-connect", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ provider, consumerRef: finalConsumerRef, groupRef: finalGroupRef, projectId }),
-        });
-        url = await response.text();
         return {
           content: [
-            { type: "text", text: `OAuth URL generated for ${provider}: ${url}` },
+            {
+              type: "text",
+              text: `No installation found for ${params.provider}`,
+            },
           ],
         };
       } catch (err) {
@@ -276,51 +281,143 @@ export const createStartOAuthTool = async (server: Server, settings: ClientSetti
         return {
           isError: true,
           content: [
-            { type: "text", text: `Error generating OAuth URL: ${err instanceof Error ? err.message : err}` },
+            {
+              type: "text",
+              text: `Error: ${err instanceof Error ? err.message : err}`,
+            },
           ],
         };
       }
-    }
+    },
+  );
+};
+
+/**
+ * Creates an OAuth tool for the MCP server.
+ *
+ * @param server - The MCP server instance
+ * @returns A configured MCP tool for handling OAuth flows
+ */
+export const createStartOAuthTool = async (
+  server: Server,
+  settings: ClientSettings,
+) => {
+  // @ts-ignore
+  return server.tool(
+    "start-oauth",
+    startOAuthToolDescription,
+    startOAuthInputSchema.shape,
+    async (params: StartOAuthInputType): Promise<MCPResponse> => {
+      const { provider, groupRef, consumerRef } = params;
+      const finalConsumerRef =
+        consumerRef || Math.random().toString(36).substring(2, 15);
+      const finalGroupRef = settings?.groupRef || groupRef || "";
+      const projectId =
+        settings?.project || process.env.AMPERSAND_PROJECT_ID || "";
+      let url = "";
+      try {
+        const response = await fetch(
+          "https://api.withampersand.com/v1/oauth-connect",
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              provider,
+              consumerRef: finalConsumerRef,
+              groupRef: finalGroupRef,
+              projectId,
+            }),
+          },
+        );
+        url = await response.text();
+        return {
+          content: [
+            {
+              type: "text",
+              text: `OAuth URL generated for ${provider}: ${url}`,
+            },
+          ],
+        };
+      } catch (err) {
+        Sentry.captureException(err);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: `Error generating OAuth URL: ${err instanceof Error ? err.message : err}`,
+            },
+          ],
+        };
+      }
+    },
   );
 };
 
 /**
  * Creates a send request tool for the MCP server.
- * 
+ *
  * @param server - The MCP server instance
  * @returns A configured MCP tool for making API calls
  */
-export const createSendRequestTool = async (server: Server, settings: ClientSettings) => {
+export const createSendRequestTool = async (
+  server: Server,
+  settings: ClientSettings,
+) => {
   // @ts-ignore
   return server.tool(
     "send-request",
     sendRequestToolDescription,
     sendRequestInputSchema.shape,
     async (params: SendRequestInputType): Promise<MCPResponse> => {
-      const { provider, body, endpoint, method, headers = {}, installationId } = params;
+      const {
+        provider,
+        body,
+        endpoint,
+        method,
+        headers = {},
+        installationId,
+      } = params;
       try {
-        const projectId = settings?.project || process.env.AMPERSAND_PROJECT_ID || "";
+        const projectId =
+          settings?.project || process.env.AMPERSAND_PROJECT_ID || "";
         const apiKey = settings?.apiKey || process.env.AMPERSAND_API_KEY || "";
-        const integrationName = settings?.integrationName || process.env.AMPERSAND_INTEGRATION_NAME || "";
-        const finalInstallationId = installationId ?? (await ensureInstallationExists(provider, apiKey, projectId, integrationName));
+        const integrationName =
+          settings?.integrationName ||
+          process.env.AMPERSAND_INTEGRATION_NAME ||
+          "";
+        const finalInstallationId =
+          installationId ??
+          (await ensureInstallationExists(
+            provider,
+            apiKey,
+            projectId,
+            integrationName,
+          ));
 
-        const response = await fetch(`https://proxy.withampersand.com/${endpoint}`, {
-          method,
-          headers: {
-            ...headers,
-            "Content-Type": "application/json",
-            "x-amp-project-id": projectId,
-            "x-api-key": apiKey,
-            "x-amp-proxy-version": "1",
-            "x-amp-installation-id": finalInstallationId,
+        const response = await fetch(
+          `https://proxy.withampersand.com/${endpoint}`,
+          {
+            method,
+            headers: {
+              ...headers,
+              "Content-Type": "application/json",
+              "x-amp-project-id": projectId,
+              "x-api-key": apiKey,
+              "x-amp-proxy-version": "1",
+              "x-amp-installation-id": finalInstallationId,
+            },
+            body: body ? JSON.stringify(body) : undefined,
           },
-          body: body ? JSON.stringify(body) : undefined,
-        });
+        );
 
         const responseData = await response.json();
         return {
           content: [
-            { type: "text", text: `API call successful. Status: ${response.status}` },
+            {
+              type: "text",
+              text: `API call successful. Status: ${response.status}`,
+            },
             { type: "text", text: `Response: ${JSON.stringify(responseData)}` },
           ],
         };
@@ -329,10 +426,13 @@ export const createSendRequestTool = async (server: Server, settings: ClientSett
         return {
           isError: true,
           content: [
-            { type: "text", text: `Error making API call: ${err instanceof Error ? err.message : err}` },
+            {
+              type: "text",
+              text: `Error making API call: ${err instanceof Error ? err.message : err}`,
+            },
           ],
         };
       }
-    }
+    },
   );
-}; 
+};

--- a/sdk/lib/aisdk.ts
+++ b/sdk/lib/aisdk.ts
@@ -1,1 +1,1 @@
-export * from "./adapters/aisdk"; 
+export * from "./adapters/aisdk";

--- a/sdk/lib/mastra.ts
+++ b/sdk/lib/mastra.ts
@@ -1,1 +1,1 @@
-export * from "./adapters/mastra"; 
+export * from "./adapters/mastra";

--- a/sdk/lib/mcp.ts
+++ b/sdk/lib/mcp.ts
@@ -1,1 +1,1 @@
-export * from "./adapters/mcp"; 
+export * from "./adapters/mcp";

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -24,7 +24,9 @@
     "build": "vite build --mode lib",
     "start": "node dist/index.js",
     "inspect": "npx @modelcontextprotocol/inspector node dist/index.js",
-    "publish": "npm publish --access public"
+    "publish": "npm publish --access public",
+    "lint": "eslint lib --ext .ts",
+    "format": "prettier --write \"lib/**/*.ts\""
   },
   "publishConfig": {
     "access": "public",

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,6 @@
+{
+    "pipeline": {
+        "lint": {},
+        "format": {}
+    }
+}


### PR DESCRIPTION
- Added .eslintrc.json for TypeScript linting configuration.
- Created .lintstagedrc.json to run ESLint and Prettier on staged TypeScript files.
- Introduced .prettierrc.json for Prettier configuration.
- Updated package.json to include necessary devDependencies and scripts for linting and formatting.
- Enhanced .gitignore to exclude .vscode and .turbo directories.
- Added turbo.json for task management.
- Implemented Husky pre-commit hook to run lint-staged.
- Updated example and mcp-server package.json files to include linting and formatting scripts.