### PR TITLE
[ENG-3258] feat: add providerWorkspaceRef support for multi-workspace providers

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -28,6 +28,7 @@ export const clientSettings = {
   integrationName: integrationName,
   apiKey: process.env.AMPERSAND_API_KEY || '',
   groupRef: groupRef,
+  providerWorkspaceRef: '', // Optional workspace reference for multi-workspace providers
 };
 
 export type ClientSettings = typeof clientSettings;

--- a/mcp-server/src/oauth.ts
+++ b/mcp-server/src/oauth.ts
@@ -31,6 +31,8 @@ export async function createStartOAuthTool(
         const consumerRef = crypto.randomUUID();
         const groupRef = settings?.groupRef || process.env.AMPERSAND_GROUP_REF;
         const projectId = settings?.project || process.env.AMPERSAND_PROJECT_ID;
+        const finalProviderWorkspaceRef =
+          settings?.providerWorkspaceRef || providerWorkspaceRef;
         const apiKey = settings?.apiKey || '';
         const options: RequestInit = {
           method: 'POST',
@@ -43,7 +45,9 @@ export async function createStartOAuthTool(
             consumerRef,
             groupRef,
             projectId,
-            ...(providerWorkspaceRef && { providerWorkspaceRef }),
+            ...(finalProviderWorkspaceRef && {
+              providerWorkspaceRef: finalProviderWorkspaceRef,
+            }),
           }),
         };
         console.log(

--- a/mcp-server/src/oauth.ts
+++ b/mcp-server/src/oauth.ts
@@ -2,6 +2,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { providerSchema } from './schemas';
 import { ClientSettings } from '.';
 import crypto from 'crypto';
+import { z } from 'zod';
 
 export async function createStartOAuthTool(
   server: Server,
@@ -13,8 +14,18 @@ export async function createStartOAuthTool(
     `Connect to a SaaS tool provider using the Ampersand OAuth flow. The tool will return a clickable link to the OAuth flow for the user to click.`,
     {
       provider: providerSchema,
+      providerWorkspaceRef: z
+        .string()
+        .optional()
+        .describe('Optional workspace reference for multi-workspace providers'),
     },
-    async ({ provider }: { provider: string }) => {
+    async ({
+      provider,
+      providerWorkspaceRef,
+    }: {
+      provider: string;
+      providerWorkspaceRef?: string;
+    }) => {
       let oAuthUrl = '';
       try {
         const consumerRef = crypto.randomUUID();
@@ -27,7 +38,13 @@ export async function createStartOAuthTool(
             'Content-Type': 'application/json',
             'X-Api-Key': apiKey,
           },
-          body: JSON.stringify({ provider, consumerRef, groupRef, projectId }),
+          body: JSON.stringify({
+            provider,
+            consumerRef,
+            groupRef,
+            projectId,
+            ...(providerWorkspaceRef && { providerWorkspaceRef }),
+          }),
         };
         console.log(
           '[START-OAUTH] API request to oauthConnect: ',

--- a/sdk/lib/adapters/mcp.ts
+++ b/sdk/lib/adapters/mcp.ts
@@ -43,6 +43,7 @@ type ClientSettings = {
   integrationName: string;
   apiKey: string;
   groupRef: string;
+  providerWorkspaceRef: string;
 };
 
 /**
@@ -310,13 +311,13 @@ export const createStartOAuthTool = async (
     startOAuthToolDescription,
     startOAuthInputSchema.shape,
     async (params: StartOAuthInputType): Promise<MCPResponse> => {
-      const { provider, groupRef, consumerRef } = params;
+      const { provider, groupRef, consumerRef, providerWorkspaceRef } = params;
       const finalConsumerRef =
         consumerRef || Math.random().toString(36).substring(2, 15);
       const finalGroupRef = settings?.groupRef || groupRef || '';
       const projectId =
         settings?.project || process.env.AMPERSAND_PROJECT_ID || '';
-      let url = '';
+
       try {
         const response = await fetch(
           'https://api.withampersand.com/v1/oauth-connect',
@@ -328,10 +329,11 @@ export const createStartOAuthTool = async (
               consumerRef: finalConsumerRef,
               groupRef: finalGroupRef,
               projectId,
+              providerWorkspaceRef,
             }),
           },
         );
-        url = await response.text();
+        const url = await response.text();
         return {
           content: [
             {

--- a/sdk/lib/adapters/mcp.ts
+++ b/sdk/lib/adapters/mcp.ts
@@ -43,7 +43,7 @@ type ClientSettings = {
   integrationName: string;
   apiKey: string;
   groupRef: string;
-  providerWorkspaceRef: string;
+  providerWorkspaceRef?: string;
 };
 
 /**
@@ -317,6 +317,8 @@ export const createStartOAuthTool = async (
       const finalGroupRef = settings?.groupRef || groupRef || '';
       const projectId =
         settings?.project || process.env.AMPERSAND_PROJECT_ID || '';
+      const finalProviderWorkspaceRef =
+        settings?.providerWorkspaceRef || providerWorkspaceRef;
 
       try {
         const response = await fetch(
@@ -329,7 +331,9 @@ export const createStartOAuthTool = async (
               consumerRef: finalConsumerRef,
               groupRef: finalGroupRef,
               projectId,
-              providerWorkspaceRef,
+              ...(finalProviderWorkspaceRef && {
+                providerWorkspaceRef: finalProviderWorkspaceRef,
+              }),
             }),
           },
         );


### PR DESCRIPTION
## Summary
- Add `providerWorkspaceRef` support to OAuth flow for multi-workspace providers
- Implement consistent fallback order prioritizing settings over parameters
- Add optional workspace reference parameter to MCP tools

## Details

### Multi-Workspace Provider Support
Some SaaS providers (e.g., Slack, Microsoft Teams) support multiple workspaces per user account. This PR adds support for specifying which workspace to connect to during OAuth:

- **New parameter**: `providerWorkspaceRef` (optional) added to `start-oauth` tool
- **Settings support**: Added to `ClientSettings` type for configuration
- **Conditional inclusion**: Only included in OAuth request when provided

### Fallback Order Consistency
Implements a consistent fallback order across both SDK and mcp-server:
```typescript
// Settings take precedence over parameters
const finalProviderWorkspaceRef = 
  settings?.providerWorkspaceRef || providerWorkspaceRef;
```

This ensures that:
1. Configuration settings are always prioritized
2. Tool parameters serve as runtime overrides when settings are not provided
3. Behavior is consistent with other configuration values (groupRef, projectId, etc.)

### API Changes

#### MCP Server (`mcp-server/src/oauth.ts`)
- Added `providerWorkspaceRef` parameter to start-oauth tool
- Implements fallback logic for workspace reference

#### SDK (`sdk/lib/adapters/mcp.ts`)
- Added `providerWorkspaceRef?: string` to `ClientSettings` type
- Updated `createStartOAuthTool` to handle workspace references
- Conditionally includes workspace ref in OAuth API requests

## Test plan
- [ ] Test OAuth flow without providerWorkspaceRef (existing behavior)
- [ ] Test OAuth flow with providerWorkspaceRef parameter
- [ ] Test OAuth flow with providerWorkspaceRef in settings
- [ ] Verify settings take precedence over parameters
- [ ] Test with multi-workspace providers (e.g., Slack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)